### PR TITLE
Lexer+Parser+Symbol: Change SymbolTable to use owned Vec<u8> instead of references

### DIFF
--- a/crates/pxp-lexer/src/lib.rs
+++ b/crates/pxp-lexer/src/lib.rs
@@ -19,13 +19,13 @@ pub mod stream;
 #[derive(Debug)]
 pub struct Lexer<'a, 'b> {
     state: State<'a>,
-    symbol_table: &'b mut SymbolTable<'a>,
+    symbol_table: &'b mut SymbolTable,
 }
 
 impl<'a, 'b> Lexer<'a, 'b> {
     pub fn new<B: ?Sized + AsRef<[u8]>>(
         input: &'a B,
-        symbol_table: &'b mut SymbolTable<'a>,
+        symbol_table: &'b mut SymbolTable,
     ) -> Self {
         Self {
             state: State::new(Source::new(input.as_ref())),

--- a/crates/pxp-parser/src/lib.rs
+++ b/crates/pxp-parser/src/lib.rs
@@ -58,7 +58,7 @@ pub struct ParseResult {
 
 pub fn parse<'b, B: Sized + AsRef<[u8]>>(
     input: &'b B,
-    symbol_table: &mut SymbolTable<'b>,
+    symbol_table: &mut SymbolTable,
 ) -> ParseResult {
     let mut lexer = Lexer::new(input, symbol_table);
     let tokens = match lexer.tokenize() {

--- a/crates/pxp-parser/src/state/mod.rs
+++ b/crates/pxp-parser/src/state/mod.rs
@@ -20,17 +20,17 @@ pub enum Scope {
 }
 
 #[derive(Debug)]
-pub struct State<'a> {
+pub struct State<'a, 'b> {
     pub stack: VecDeque<Scope>,
     pub stream: &'a mut TokenStream<'a>,
-    pub symbol_table: &'a SymbolTable<'a>,
+    pub symbol_table: &'b SymbolTable,
     pub attributes: Vec<AttributeGroup>,
     pub namespace_type: Option<NamespaceType>,
     pub diagnostics: Vec<Diagnostic>,
 }
 
-impl<'a> State<'a> {
-    pub fn new(tokens: &'a mut TokenStream<'a>, symbol_table: &'a SymbolTable) -> Self {
+impl<'a, 'b> State<'a, 'b> {
+    pub fn new(tokens: &'a mut TokenStream<'a>, symbol_table: &'b SymbolTable) -> Self {
         Self {
             stack: VecDeque::with_capacity(32),
             stream: tokens,

--- a/crates/pxp-symbol/src/lib.rs
+++ b/crates/pxp-symbol/src/lib.rs
@@ -5,30 +5,30 @@ use pxp_bytestring::ByteStr;
 pub type Symbol = usize;
 
 #[derive(Default, Debug, Clone)]
-pub struct SymbolTable<'s> {
-    map: HashMap<&'s [u8], Symbol>,
-    vec: Vec<&'s [u8]>,
+pub struct SymbolTable {
+    map: HashMap<Vec<u8>, Symbol>,
+    vec: Vec<Vec<u8>>,
 }
 
-impl<'s> SymbolTable<'s> {
+impl SymbolTable {
     pub fn new() -> Self {
         Self::default()
     }
 
-    pub fn intern(&mut self, contents: &'s [u8]) -> Symbol {
+    pub fn intern(&mut self, contents: &[u8]) -> Symbol {
         if let Some(symbol) = self.map.get(contents) {
             return *symbol;
         }
 
         let symbol = self.vec.len();
 
-        self.map.insert(contents, symbol);
-        self.vec.push(contents);
+        self.map.insert(contents.to_vec(), symbol);
+        self.vec.push(contents.to_vec());
 
         symbol
     }
 
-    pub fn resolve(&self, symbol: Symbol) -> Option<ByteStr<'s>> {
+    pub fn resolve(&self, symbol: Symbol) -> Option<ByteStr> {
         self.vec.get(symbol).map(|s| ByteStr::new(s))
     }
 }


### PR DESCRIPTION
The main reasoning behind this change is to allow a single `SymbolTable` to be used across multiple tokenisation & parse phases. Right now, the `SymbolTable` borrows data from the source code which means the lifetime of it is directly tied to the lifetime of the input.

By removing that lifetime dependency and instead of converting bytes into an owned `Vec<u8>`, we can use a single `SymbolTable` multiple times.

The performance impact of this change is quite minimal too. I noticed a 6% slowdown in the `laravel/framework` benchmark (translates to roughly 200ms), but I'm willing to take that hit given it improves the ergonomics.

I was kind of expecting it to perform worse than it did, given that it's allocating `Vec<u8>` on the heap, but because it's common for PHP code to contain repeated identifiers, variable names, strings, especially across multiple files (imports, type hints, etc), there are lots of re-used symbols!

This will also make it easier to use the `SymbolTable` in #21.