### PR TITLE
Indexer: Serialisable indexes

### DIFF
--- a/crates/pxp-ast/src/enums.rs
+++ b/crates/pxp-ast/src/enums.rs
@@ -7,6 +7,7 @@ use crate::identifiers::SimpleIdentifier;
 
 use crate::Expression;
 use pxp_span::Span;
+use pxp_syntax::backed_enum_type::BackedEnumType;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 
@@ -40,39 +41,6 @@ pub struct UnitEnumStatement {
     pub name: SimpleIdentifier,            // `Foo`
     pub implements: Vec<SimpleIdentifier>, // `implements Bar`
     pub body: UnitEnumBody,                // `{ ... }`
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-
-pub enum BackedEnumType {
-    String(Span, Span), // `:` + `string`
-    Int(Span, Span),    // `:` + `int`
-    Invalid(Span),
-}
-
-impl BackedEnumType {
-    pub fn is_valid(&self) -> bool {
-        match self {
-            Self::String(..) | Self::Int(..) => true,
-            Self::Invalid(..) => false,
-        }
-    }
-}
-
-impl Display for BackedEnumType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BackedEnumType::String(..) => write!(f, "string"),
-            BackedEnumType::Int(..) => write!(f, "int"),
-            BackedEnumType::Invalid(..) => write!(f, "invalid"),
-        }
-    }
-}
-
-impl Default for BackedEnumType {
-    fn default() -> Self {
-        Self::Invalid(Span::default())
-    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/pxp-ast/src/modifiers.rs
+++ b/crates/pxp-ast/src/modifiers.rs
@@ -1,25 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use pxp_span::Span;
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
-
-pub enum Visibility {
-    #[default]
-    Public,
-    Protected,
-    Private,
-}
-
-impl Display for Visibility {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Visibility::Public => write!(f, "public"),
-            Visibility::Protected => write!(f, "protected"),
-            Visibility::Private => write!(f, "private"),
-        }
-    }
-}
+use pxp_syntax::visibility::Visibility;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 

--- a/crates/pxp-indexer/Cargo.toml
+++ b/crates/pxp-indexer/Cargo.toml
@@ -19,6 +19,8 @@ discoverer = "0.2.0"
 rustyline = "13.0.0"
 serde = { version = "1.0.193", features = ["derive"] }
 pxp-syntax = { path = "../pxp-syntax" }
+dirs = "5.0.1"
+bincode = "1.3.3"
 
 [[bin]]
 name = "index"

--- a/crates/pxp-indexer/Cargo.toml
+++ b/crates/pxp-indexer/Cargo.toml
@@ -17,6 +17,8 @@ pxp-span = { path = "../pxp-span" }
 pxp-bytestring = { path = "../pxp-bytestring" }
 discoverer = "0.2.0"
 rustyline = "13.0.0"
+serde = { version = "1.0.193", features = ["derive"] }
+pxp-syntax = { path = "../pxp-syntax" }
 
 [[bin]]
 name = "index"

--- a/crates/pxp-indexer/bin/index.rs
+++ b/crates/pxp-indexer/bin/index.rs
@@ -1,6 +1,5 @@
 use std::{
     env::args,
-    io::{stdin, stdout, Write},
     path::PathBuf,
     process::exit,
     time::Instant,

--- a/crates/pxp-indexer/bin/index.rs
+++ b/crates/pxp-indexer/bin/index.rs
@@ -5,7 +5,7 @@ use std::{
     time::Instant,
 };
 
-use pxp_indexer::{Index, Indexer};
+use pxp_indexer::{Index, Indexer, write_index_to_cache, try_load_index_from_cache};
 use pxp_symbol::SymbolTable;
 use rustyline::{error::ReadlineError, DefaultEditor};
 
@@ -16,8 +16,14 @@ fn main() {
     println!("Indexing...");
     let start = Instant::now();
 
-    let mut indexer = Indexer::new();
-    let (index, symbol_table) = indexer.index(vec![directory]);
+    let mut indexer = if let Some(result) = try_load_index_from_cache(&directory) {
+        Indexer::of(result.0, result.1)
+    } else {
+        Indexer::new()
+    };
+
+    let (index, symbol_table) = indexer.index(&directory);
+    write_index_to_cache((&index, &symbol_table), &directory);
 
     let duration = start.elapsed();
 

--- a/crates/pxp-indexer/src/cache.rs
+++ b/crates/pxp-indexer/src/cache.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use pxp_symbol::SymbolTable;
+
+use crate::Index;
+
+pub fn try_load_index_from_cache(directory: &PathBuf) -> Option<(Index, SymbolTable)> {
+    // Try to load a serialised version of the index from the system cache directory.
+    // If the file doesn't exist, or if it fails to load, return None.
+    // Otherwise, return the loaded index.
+    //
+    // The cache directory is ~/.cache/pxp-indexer.
+    // The cache file is ~/.cache/pxp-indexer/{directory}.index
+
+    let cache_dir = dirs::cache_dir().unwrap().join("pxp-indexer");
+    let cache_file = cache_dir.join(directory.file_name().unwrap()).with_extension("index");
+
+    if !cache_file.exists() {
+        return None;
+    }
+
+    match std::fs::read(cache_file) {
+        Ok(contents) => match bincode::deserialize::<(Index, SymbolTable)>(&contents) {
+            Ok(index) => Some(index),
+            Err(_) => None,
+        },
+        Err(_) => None,
+    }
+}
+
+pub fn write_index_to_cache(result: (&Index, &SymbolTable), directory: &PathBuf) {
+    let cache_dir = dirs::cache_dir().unwrap().join("pxp-indexer");
+    let cache_file = cache_dir.join(directory.file_name().unwrap()).with_extension("index");
+
+    if !cache_dir.exists() {
+        std::fs::create_dir_all(cache_dir).unwrap();
+    }
+
+    let contents = bincode::serialize(&result).unwrap();
+
+    std::fs::write(cache_file, contents).unwrap();
+}

--- a/crates/pxp-indexer/src/entities.rs
+++ b/crates/pxp-indexer/src/entities.rs
@@ -1,13 +1,13 @@
 use std::fmt::{Debug, Formatter};
 
-use pxp_ast::{enums::BackedEnumType, modifiers::Visibility};
-use pxp_span::Span;
 use pxp_symbol::{Symbol, SymbolTable};
+use pxp_syntax::{visibility::Visibility, backed_enum_type::BackedEnumType};
 use pxp_type::Type;
+use serde::{Serialize, Deserialize};
 
 use crate::Location;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ConstantEntity {
     pub name: Symbol,
     pub short_name: Symbol,
@@ -15,7 +15,7 @@ pub struct ConstantEntity {
     pub location: Location,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FunctionEntity {
     pub name: Symbol,
     pub short_name: Symbol,
@@ -24,7 +24,7 @@ pub struct FunctionEntity {
     pub location: Location,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ParameterEntity {
     pub name: Symbol,
     pub reference: bool,
@@ -34,7 +34,7 @@ pub struct ParameterEntity {
     pub location: Location,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ClassLikeEntity {
     pub name: Symbol,
     pub short_name: Symbol,
@@ -58,7 +58,7 @@ pub struct ClassLikeEntity {
     pub location: Location,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ClassishConstantEntity {
     pub name: Symbol,
     pub r#type: Type,
@@ -66,7 +66,7 @@ pub struct ClassishConstantEntity {
     pub r#final: bool,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PropertyEntity {
     pub name: Symbol,
     pub r#static: bool,
@@ -75,7 +75,7 @@ pub struct PropertyEntity {
     pub default: bool,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MethodEntity {
     pub name: Symbol,
     pub visibility: Visibility,

--- a/crates/pxp-indexer/src/index.rs
+++ b/crates/pxp-indexer/src/index.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf, time::SystemTime};
 
 use pxp_symbol::{Symbol, SymbolTable};
 
@@ -14,6 +14,7 @@ pub struct Index {
     constants: HashMap<Symbol, ConstantEntity>,
     functions: HashMap<Symbol, FunctionEntity>,
     class_likes: HashMap<Symbol, ClassLikeEntity>,
+    files: HashMap<PathBuf, SystemTime>,
 }
 
 impl Index {
@@ -385,5 +386,26 @@ impl Index {
 
     pub fn get_constant(&self, symbol: Symbol) -> Option<&ConstantEntity> {
         self.constants.get(&symbol)
+    }
+
+    pub fn add_file(&mut self, path: PathBuf) {
+        let modified_at = match std::fs::metadata(&path) {
+            Ok(metadata) => metadata.modified().unwrap(),
+            Err(_) => return,
+        };
+
+        self.files.insert(path, modified_at);
+    }
+
+    pub fn should_index_file(&self, path: &PathBuf) -> bool {
+        let modified_at = match std::fs::metadata(path) {
+            Ok(metadata) => metadata.modified().unwrap(),
+            Err(_) => return true,
+        };
+
+        match self.files.get(path) {
+            Some(last_modified_at) => last_modified_at < &modified_at,
+            None => true,
+        }
     }
 }

--- a/crates/pxp-indexer/src/index.rs
+++ b/crates/pxp-indexer/src/index.rs
@@ -1,13 +1,14 @@
 use std::{collections::HashMap, path::PathBuf, time::SystemTime};
 
 use pxp_symbol::{Symbol, SymbolTable};
+use serde::{Serialize, Deserialize};
 
 use crate::{
     debuggable_entity, entities::FunctionEntity, ClassLikeEntity, ConstantEntity,
     DebuggableEntityWithSymbolTable,
 };
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Index {
     // Using Symbol as the key for entities is a good idea because it
     // allows us to do super fast lookups when we have a resolved identifier.

--- a/crates/pxp-indexer/src/indexer.rs
+++ b/crates/pxp-indexer/src/indexer.rs
@@ -77,13 +77,10 @@ impl Indexer {
         }
     }
 
-    pub fn index(&mut self, directories: Vec<PathBuf>) -> (Index, SymbolTable) {
+    pub fn index(&mut self, directory: &PathBuf) -> (Index, SymbolTable) {
         let files = discover(
             &["php"],
-            &directories
-                .iter()
-                .map(|d| d.to_str().unwrap())
-                .collect::<Vec<&str>>(),
+            &[directory.to_str().unwrap().to_string().as_str()]
         )
         .unwrap();
 

--- a/crates/pxp-indexer/src/indexer.rs
+++ b/crates/pxp-indexer/src/indexer.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fs::read,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use discoverer::discover;
@@ -15,16 +15,15 @@ use pxp_ast::{
     identifiers::{Identifier, SimpleIdentifier},
     interfaces::{InterfaceExtends, InterfaceStatement},
     literals::Literal,
-    modifiers::Visibility,
     namespaces::{BracedNamespace, UnbracedNamespace},
     properties::{Property, VariableProperty},
     traits::{TraitStatement, TraitUsage},
-    ExpressionKind, FunctionCallExpression, GroupUseStatement, Use, UseKind, UseStatement,
+    ExpressionKind, FunctionCallExpression, GroupUseStatement, UseKind, UseStatement,
 };
-use pxp_bytestring::ByteStr;
 use pxp_parser::parse;
 use pxp_span::Span;
 use pxp_symbol::{Symbol, SymbolTable};
+use pxp_syntax::visibility::Visibility;
 use pxp_token::{Token, TokenKind};
 use pxp_type::Type;
 use pxp_visitor::{

--- a/crates/pxp-indexer/src/indexer.rs
+++ b/crates/pxp-indexer/src/indexer.rs
@@ -96,12 +96,18 @@ impl Indexer {
     }
 
     fn index_file(&mut self, file: PathBuf) {
+        if !self.index.should_index_file(&file) {
+            return;
+        }
+
         let contents = read(&file).unwrap();
         let mut program = parse(&contents, &mut self.symbol_table);
 
         self.scope = Scope::default();
         self.scope.file = file.to_str().unwrap().to_string();
         self.visit(&mut program.ast);
+
+        self.index.add_file(file);
     }
 
     fn qualify(&mut self, symbol: Symbol, token: Token) -> Symbol {

--- a/crates/pxp-indexer/src/lib.rs
+++ b/crates/pxp-indexer/src/lib.rs
@@ -2,8 +2,10 @@ mod entities;
 mod index;
 mod indexer;
 mod location;
+mod cache;
 
 pub use entities::*;
 pub use index::Index;
 pub use indexer::Indexer;
 pub use location::Location;
+pub use cache::{try_load_index_from_cache, write_index_to_cache};

--- a/crates/pxp-indexer/src/location.rs
+++ b/crates/pxp-indexer/src/location.rs
@@ -1,6 +1,7 @@
 use pxp_span::Span;
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Location {
     pub file: String,
     pub span: Span,

--- a/crates/pxp-indexer/tests/integration.rs
+++ b/crates/pxp-indexer/tests/integration.rs
@@ -14,11 +14,11 @@ macro_rules! assert_matches {
 #[test]
 fn it_indexes_correctly() {
     let mut indexer = Indexer::new();
-    let (index, mut symbol_table) = indexer.index(vec![PathBuf::from(format!(
+    let (index, mut symbol_table) = indexer.index(&PathBuf::from(format!(
         "{}/{}",
         env!("CARGO_MANIFEST_DIR"),
         "example-php"
-    ))]);
+    )));
 
     assert_eq!(index.get_number_of_functions(), 2);
     assert_eq!(index.get_number_of_class_likes(), 8);

--- a/crates/pxp-parser/src/internal/enums.rs
+++ b/crates/pxp-parser/src/internal/enums.rs
@@ -7,7 +7,6 @@ use pxp_ast::enums::BackedEnumBody;
 use pxp_ast::enums::BackedEnumCase;
 use pxp_ast::enums::BackedEnumMember;
 use pxp_ast::enums::BackedEnumStatement;
-use pxp_ast::enums::BackedEnumType;
 use pxp_ast::enums::UnitEnumBody;
 use pxp_ast::enums::UnitEnumCase;
 use pxp_ast::enums::UnitEnumMember;
@@ -16,6 +15,7 @@ use pxp_ast::StatementKind;
 use pxp_diagnostics::DiagnosticKind;
 use pxp_diagnostics::Severity;
 use pxp_span::Span;
+use pxp_syntax::backed_enum_type::BackedEnumType;
 use pxp_token::TokenKind;
 
 use super::classes::member;

--- a/crates/pxp-span/Cargo.toml
+++ b/crates/pxp-span/Cargo.toml
@@ -7,3 +7,4 @@ license-file.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0.193", features = ["derive"] }

--- a/crates/pxp-span/src/lib.rs
+++ b/crates/pxp-span/src/lib.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct Span {
     pub start: Position,
     pub end: Position,
@@ -18,7 +20,7 @@ impl Span {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct Position {
     pub offset: usize,
     pub line: usize,

--- a/crates/pxp-symbol/Cargo.toml
+++ b/crates/pxp-symbol/Cargo.toml
@@ -8,3 +8,4 @@ license-file.workspace = true
 
 [dependencies]
 pxp-bytestring = { path = "../pxp-bytestring" }
+serde = { version = "1.0.193", features = ["derive"] }

--- a/crates/pxp-symbol/src/lib.rs
+++ b/crates/pxp-symbol/src/lib.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
 use pxp_bytestring::ByteStr;
+use serde::{Serialize, Deserialize};
 
 pub type Symbol = usize;
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct SymbolTable {
     map: HashMap<Vec<u8>, Symbol>,
     vec: Vec<Vec<u8>>,

--- a/crates/pxp-syntax/Cargo.toml
+++ b/crates/pxp-syntax/Cargo.toml
@@ -9,3 +9,4 @@ license-file.workspace = true
 [dependencies]
 pxp-span = { path = "../pxp-span" }
 pxp-symbol = { path = "../pxp-symbol" }
+serde = { version = "1.0.193", features = ["derive"] }

--- a/crates/pxp-syntax/src/backed_enum_type.rs
+++ b/crates/pxp-syntax/src/backed_enum_type.rs
@@ -1,0 +1,37 @@
+use std::fmt::Display;
+
+use pxp_span::Span;
+use serde::{Serialize, Deserialize};
+
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum BackedEnumType {
+    String(Span, Span), // `:` + `string`
+    Int(Span, Span),    // `:` + `int`
+    Invalid(Span),
+}
+
+impl BackedEnumType {
+    pub fn is_valid(&self) -> bool {
+        match self {
+            Self::String(..) | Self::Int(..) => true,
+            Self::Invalid(..) => false,
+        }
+    }
+}
+
+impl Display for BackedEnumType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BackedEnumType::String(..) => write!(f, "string"),
+            BackedEnumType::Int(..) => write!(f, "int"),
+            BackedEnumType::Invalid(..) => write!(f, "invalid"),
+        }
+    }
+}
+
+impl Default for BackedEnumType {
+    fn default() -> Self {
+        Self::Invalid(Span::default())
+    }
+}

--- a/crates/pxp-syntax/src/lib.rs
+++ b/crates/pxp-syntax/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod comments;
+pub mod visibility;
+pub mod backed_enum_type;

--- a/crates/pxp-syntax/src/visibility.rs
+++ b/crates/pxp-syntax/src/visibility.rs
@@ -1,0 +1,22 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
+
+pub enum Visibility {
+    #[default]
+    Public,
+    Protected,
+    Private,
+}
+
+impl Display for Visibility {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Visibility::Public => write!(f, "public"),
+            Visibility::Protected => write!(f, "protected"),
+            Visibility::Private => write!(f, "private"),
+        }
+    }
+}

--- a/crates/pxp-type/Cargo.toml
+++ b/crates/pxp-type/Cargo.toml
@@ -9,3 +9,4 @@ license-file.workspace = true
 [dependencies]
 pxp-symbol = { path = "../pxp-symbol" }
 pxp-span = { path = "../pxp-span" }
+serde = { version = "1.0.193", features = ["derive"] }

--- a/crates/pxp-type/src/lib.rs
+++ b/crates/pxp-type/src/lib.rs
@@ -2,8 +2,9 @@ use std::fmt::{Debug, Display};
 
 use pxp_span::Span;
 use pxp_symbol::{Symbol, SymbolTable};
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 
 pub enum Type {
     Named(Span, Symbol),


### PR DESCRIPTION
This introduces a few APIs for serialising and retrieving index results from a "cache". The cache directory is OS-specific and determined by the `dirs` crate.

Serialising the index definitely improves the time it takes to index multiple times. Indexing the entirety of `laravel/framework` with `vendor`, it went from a ~2.5s full index to ~400ms with cache. The cached version since has a 400ms duration because it needs to loop through all files and check the `mtime` to see if it needs to be re-indexed.

Closes #24.