### PR TITLE
Lexer: Introduce a new "immediate" mode to the lexer

### DIFF
--- a/crates/pxp-lexer/bin/tokenise.rs
+++ b/crates/pxp-lexer/bin/tokenise.rs
@@ -9,13 +9,14 @@ fn main() {
     let args = args().skip(1).collect::<Vec<_>>();
 
     if args.is_empty() {
-        eprintln!("Usage: tokenise <path> [--debug]");
+        eprintln!("Usage: tokenise <path> --debug --immediate");
         exit(1);
     }
 
     let path = args.first().unwrap();
     let path = Path::new(path);
     let mut symbol_table = SymbolTable::new();
+    let immediate = args.contains(&"--immediate".to_string());
 
     if path.is_dir() {
         let mut errors = Vec::new();
@@ -29,7 +30,7 @@ fn main() {
             let contents = std::fs::read(file).unwrap();
             let mut lexer = Lexer::new(&contents[..], &mut symbol_table);
 
-            match lexer.tokenize() {
+            match if immediate { lexer.tokenize_in_immediate_mode() } else { lexer.tokenize() } {
                 Ok(_) => {
                     print!(".");
                 }
@@ -52,7 +53,7 @@ fn main() {
     } else {
         let contents = std::fs::read(path).unwrap();
         let mut lexer = Lexer::new(&contents[..], &mut symbol_table);
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = if immediate { lexer.tokenize_in_immediate_mode() } else { lexer.tokenize() }.unwrap();
 
         if args.contains(&"--debug".to_string()) {
             dbg_tokens(&symbol_table, &tokens);

--- a/crates/pxp-lexer/src/lib.rs
+++ b/crates/pxp-lexer/src/lib.rs
@@ -30,6 +30,14 @@ impl<'a, 'b> Lexer<'a, 'b> {
         }
     }
 
+    /// Tokenize the input in immediate mode, which means that the lexer will immediately
+    /// enter scripting state and start parsing PHP tokens.
+    pub fn tokenize_in_immediate_mode(&'b mut self) -> SyntaxResult<Vec<Token>> {
+        self.state.replace(StackFrame::Scripting);
+
+        self.tokenize()
+    }
+
     pub fn tokenize(&'b mut self) -> SyntaxResult<Vec<Token>> {
         let mut tokens = Vec::new();
 


### PR DESCRIPTION
Closes #13.

This new "immediate" mode instantly puts the lexer into `Scripting` mode, which means it can be used to generate tokens for PHP code outside of `<?php` tags.

If a `?>` is encountered, it will fail since it's not designed to tokenise InlineHtml. An example of where this might be used is inside of a Blade parser or similar, where PHP code is used but not inside of PHP tags.