### PR TITLE
Full open tag span position fixed

### DIFF
--- a/crates/pxp-lexer/src/lib.rs
+++ b/crates/pxp-lexer/src/lib.rs
@@ -154,6 +154,7 @@ impl<'a, 'b> Lexer<'a, 'b> {
             if self.state.source.at_case_insensitive(b"<?php", 5) {
                 let inline_span = self.state.source.span();
 
+                self.state.source.start_token();
                 self.state.source.read_and_skip(5);
                 let tag_span = self.state.source.span();
 

--- a/crates/pxp-parser/tests/__snapshots__/inline_html_with_php.snap
+++ b/crates/pxp-parser/tests/__snapshots__/inline_html_with_php.snap
@@ -1,0 +1,208 @@
+[
+    Statement {
+        id: 2,
+        kind: InlineHtml(
+            InlineHtmlStatement {
+                html: Token {
+                    kind: InlineHtml,
+                    span: Span {
+                        start: Position {
+                            offset: 0,
+                            line: 1,
+                            column: 0,
+                        },
+                        end: Position {
+                            offset: 4,
+                            line: 1,
+                            column: 4,
+                        },
+                    },
+                    symbol: Some(
+                        Symbol("<h1>"),
+                    ),
+                },
+            },
+        ),
+        span: Span {
+            start: Position {
+                offset: 0,
+                line: 1,
+                column: 0,
+            },
+            end: Position {
+                offset: 4,
+                line: 1,
+                column: 4,
+            },
+        },
+        comments: CommentGroup {
+            comments: [],
+        },
+    },
+    Statement {
+        id: 3,
+        kind: FullOpeningTag(
+            FullOpeningTagStatement {
+                span: Span {
+                    start: Position {
+                        offset: 4,
+                        line: 1,
+                        column: 4,
+                    },
+                    end: Position {
+                        offset: 9,
+                        line: 1,
+                        column: 9,
+                    },
+                },
+            },
+        ),
+        span: Span {
+            start: Position {
+                offset: 4,
+                line: 1,
+                column: 4,
+            },
+            end: Position {
+                offset: 9,
+                line: 1,
+                column: 9,
+            },
+        },
+        comments: CommentGroup {
+            comments: [],
+        },
+    },
+    Statement {
+        id: 5,
+        kind: Echo(
+            EchoStatement {
+                echo: Span {
+                    start: Position {
+                        offset: 10,
+                        line: 1,
+                        column: 10,
+                    },
+                    end: Position {
+                        offset: 14,
+                        line: 1,
+                        column: 14,
+                    },
+                },
+                values: [
+                    Expression {
+                        id: 4,
+                        kind: Literal(
+                            Literal {
+                                kind: String,
+                                token: Token {
+                                    kind: LiteralDoubleQuotedString,
+                                    span: Span {
+                                        start: Position {
+                                            offset: 16,
+                                            line: 1,
+                                            column: 16,
+                                        },
+                                        end: Position {
+                                            offset: 29,
+                                            line: 1,
+                                            column: 29,
+                                        },
+                                    },
+                                    symbol: Some(
+                                        Symbol("Hello, world!"),
+                                    ),
+                                },
+                            },
+                        ),
+                        span: Span {
+                            start: Position {
+                                offset: 16,
+                                line: 1,
+                                column: 16,
+                            },
+                            end: Position {
+                                offset: 29,
+                                line: 1,
+                                column: 29,
+                            },
+                        },
+                        comments: CommentGroup {
+                            comments: [],
+                        },
+                    },
+                ],
+                ending: CloseTag(
+                    Span {
+                        start: Position {
+                            offset: 31,
+                            line: 1,
+                            column: 31,
+                        },
+                        end: Position {
+                            offset: 33,
+                            line: 1,
+                            column: 33,
+                        },
+                    },
+                ),
+            },
+        ),
+        span: Span {
+            start: Position {
+                offset: 10,
+                line: 1,
+                column: 10,
+            },
+            end: Position {
+                offset: 33,
+                line: 1,
+                column: 33,
+            },
+        },
+        comments: CommentGroup {
+            comments: [],
+        },
+    },
+    Statement {
+        id: 6,
+        kind: InlineHtml(
+            InlineHtmlStatement {
+                html: Token {
+                    kind: InlineHtml,
+                    span: Span {
+                        start: Position {
+                            offset: 33,
+                            line: 1,
+                            column: 33,
+                        },
+                        end: Position {
+                            offset: 38,
+                            line: 1,
+                            column: 38,
+                        },
+                    },
+                    symbol: Some(
+                        Symbol("</h1>"),
+                    ),
+                },
+            },
+        ),
+        span: Span {
+            start: Position {
+                offset: 33,
+                line: 1,
+                column: 33,
+            },
+            end: Position {
+                offset: 38,
+                line: 1,
+                column: 38,
+            },
+        },
+        comments: CommentGroup {
+            comments: [],
+        },
+    },
+]
+---

--- a/crates/pxp-parser/tests/fixtures/html/inline-html-with-php.php
+++ b/crates/pxp-parser/tests/fixtures/html/inline-html-with-php.php
@@ -1,0 +1,1 @@
+<h1><?php echo "Hello, world!" ?></h1>

--- a/crates/pxp-parser/tests/parser.rs
+++ b/crates/pxp-parser/tests/parser.rs
@@ -4,12 +4,11 @@ use pxp_parser::parse;
 use pxp_symbol::SymbolTable;
 use snappers::{snap, Snapper};
 
-// Tags & Inline HTML
+// Tags
 snap!(snapper, empty_file, process("fixtures/tags/empty-file.php"));
 snap!(snapper, tag, process("fixtures/tags/tag.php"));
 snap!(snapper, short_tag, process("fixtures/tags/short-tag.php"));
 snap!(snapper, echo_tag, process("fixtures/tags/echo-tag.php"));
-snap!(snapper, html, process("fixtures/tags/html.php"));
 
 // Echo
 snap!(snapper, simple_echo, process("fixtures/echo/simple-echo.php"));
@@ -198,6 +197,10 @@ snap!(snapper, method_with_attributes, process("fixtures/methods/method-with-att
 snap!(snapper, unqualified_identifier, process("fixtures/identifiers/unqualified-identifier.php"));
 snap!(snapper, qualified_identifier, process("fixtures/identifiers/qualified-identifier.php"));
 snap!(snapper, fully_qualified_identifier, process("fixtures/identifiers/fully-qualified-identifier.php"));
+
+// Inline HTML
+snap!(snapper, html, process("fixtures/tags/html.php"));
+snap!(snapper, inline_html_with_php, process("fixtures/html/inline-html-with-php.php"));
 
 fn snapper() -> Snapper {
     Snapper::new(


### PR DESCRIPTION
I was working on #47 when I found this little bug:

```php
<html><?php
```

The lexer sets `0` as the `column` of the `<?php` token span. This PR fixes it.

PS: I've tested with a test case, but I didn't add it so as not to pollute the beautifully organized code (I don't think you need bug test cases yet). but if you do let me, I'll add the test case as well.