### PR TITLE
Visitor: Introduce non-mut version of `Visitor`

### DIFF
--- a/crates/pxp-visitor/Cargo.toml
+++ b/crates/pxp-visitor/Cargo.toml
@@ -12,3 +12,4 @@ pxp-syntax = { path = "../pxp-syntax" }
 pxp-span = { path = "../pxp-span" }
 pxp-type = { path = "../pxp-type" }
 pxp-symbol = { path = "../pxp-symbol" }
+paste = "1.0.14"

--- a/crates/pxp-visitor/src/lib.rs
+++ b/crates/pxp-visitor/src/lib.rs
@@ -1,5 +1,5 @@
 mod visitor;
 mod walk;
 
-pub use visitor::VisitorMut;
+pub use visitor::{VisitorMut, Visitor};
 pub use walk::*;

--- a/crates/pxp-visitor/src/lib.rs
+++ b/crates/pxp-visitor/src/lib.rs
@@ -1,5 +1,5 @@
 mod visitor;
 mod walk;
 
-pub use visitor::Visitor;
+pub use visitor::VisitorMut;
 pub use walk::*;

--- a/crates/pxp-visitor/src/visitor.rs
+++ b/crates/pxp-visitor/src/visitor.rs
@@ -705,3 +705,647 @@ pub trait VisitorMut {
         walk_type_mut(self, node);
     }
 }
+
+pub trait Visitor {
+    fn visit(&mut self, node: &[Statement]) {
+        walk(self, node);
+    }
+
+    fn visit_statement(&mut self, node: &Statement) {
+        walk_statement(self, node)
+    }
+
+    fn visit_expression(&mut self, node: &Expression) {
+        walk_expression(self, node)
+    }
+
+    fn visit_full_opening_tag(&mut self, _: &FullOpeningTagStatement) {}
+    fn visit_short_opening_tag(&mut self, _: &ShortOpeningTagStatement) {}
+    fn visit_echo_opening_tag(&mut self, _: &EchoOpeningTagStatement) {}
+    fn visit_closing_tag(&mut self, _: &ClosingTagStatement) {}
+
+    fn visit_inline_html(&mut self, _: &InlineHtmlStatement) {}
+    fn visit_halt_compiler(&mut self, _: &HaltCompilerStatement) {}
+
+    fn visit_label(&mut self, node: &LabelStatement) {
+        walk_label(self, node)
+    }
+
+    fn visit_goto(&mut self, node: &GotoStatement) {
+        walk_goto(self, node)
+    }
+
+    fn visit_static(&mut self, node: &StaticStatement) {
+        walk_static(self, node)
+    }
+
+    fn visit_static_var(&mut self, var: &StaticVar) {
+        walk_static_var(self, var)
+    }
+
+    fn visit_global(&mut self, node: &GlobalStatement) {
+        walk_global(self, node);
+    }
+
+    fn visit_do_while(&mut self, node: &DoWhileStatement) {
+        walk_do_while(self, node)
+    }
+
+    fn visit_while(&mut self, node: &WhileStatement) {
+        walk_while(self, node)
+    }
+
+    fn visit_while_statement_body(&mut self, node: &WhileStatementBody) {
+        walk_while_statement_body(self, node)
+    }
+
+    fn visit_for(&mut self, node: &ForStatement) {
+        walk_for(self, node)
+    }
+
+    fn visit_for_statement_iterator(&mut self, node: &ForStatementIterator) {
+        walk_for_statement_iterator(self, node);
+    }
+
+    fn visit_for_statement_body(&mut self, node: &ForStatementBody) {
+        walk_for_statement_body(self, node);
+    }
+
+    fn visit_foreach(&mut self, node: &ForeachStatement) {
+        walk_foreach(self, node)
+    }
+
+    fn visit_foreach_statement_iterator(&mut self, node: &ForeachStatementIterator) {
+        walk_foreach_statement_iterator(self, node)
+    }
+
+    fn visit_foreach_statement_body(&mut self, node: &ForeachStatementBody) {
+        walk_foreach_statement_body(self, node)
+    }
+
+    fn visit_if(&mut self, node: &IfStatement) {
+        walk_if(self, node)
+    }
+
+    fn visit_if_statement_body(&mut self, node: &IfStatementBody) {
+        walk_if_statement_body(self, node)
+    }
+
+    fn visit_if_statement_elseif(&mut self, node: &IfStatementElseIf) {
+        walk_if_statement_elseif(self, node)
+    }
+
+    fn visit_if_statement_else(&mut self, node: &IfStatementElse) {
+        walk_if_statement_else(self, node)
+    }
+
+    fn visit_if_statement_elseif_block(&mut self, node: &IfStatementElseIfBlock) {
+        walk_if_statement_elseif_block(self, node)
+    }
+
+    fn visit_if_statement_else_block(&mut self, node: &IfStatementElseBlock) {
+        walk_if_statement_else_block(self, node)
+    }
+
+    fn visit_switch(&mut self, node: &SwitchStatement) {
+        walk_switch(self, node)
+    }
+
+    fn visit_switch_case(&mut self, node: &Case) {
+        walk_switch_case(self, node)
+    }
+
+    fn visit_level(&mut self, node: &Level) {
+        walk_level(self, node)
+    }
+
+    fn visit_break(&mut self, node: &BreakStatement) {
+        walk_break(self, node)
+    }
+
+    fn visit_continue(&mut self, node: &ContinueStatement) {
+        walk_continue(self, node)
+    }
+
+    fn visit_constant(&mut self, node: &ConstantStatement) {
+        walk_constant(self, node)
+    }
+
+    fn visit_constant_entry(&mut self, node: &ConstantEntry) {
+        walk_constant_entry(self, node)
+    }
+
+    fn visit_function(&mut self, node: &FunctionStatement) {
+        walk_function(self, node)
+    }
+
+    fn visit_function_parameter_list(&mut self, node: &FunctionParameterList) {
+        walk_function_parameter_list(self, node)
+    }
+
+    fn visit_function_parameter(&mut self, node: &FunctionParameter) {
+        walk_function_parameter(self, node)
+    }
+
+    fn visit_function_body(&mut self, node: &FunctionBody) {
+        walk_function_body(self, node)
+    }
+
+    fn visit_class(&mut self, node: &ClassStatement) {
+        walk_class(self, node)
+    }
+
+    fn visit_class_extends(&mut self, node: &ClassExtends) {
+        walk_class_extends(self, node)
+    }
+
+    fn visit_class_implements(&mut self, node: &ClassImplements) {
+        walk_class_implements(self, node)
+    }
+
+    fn visit_class_body(&mut self, node: &ClassBody) {
+        walk_class_body(self, node)
+    }
+
+    fn visit_classish_member(&mut self, node: &ClassishMember) {
+        walk_classish_member(self, node)
+    }
+
+    fn visit_classish_constant(&mut self, node: &ClassishConstant) {
+        walk_classish_constant(self, node)
+    }
+
+    fn visit_trait_usage(&mut self, node: &TraitUsage) {
+        walk_trait_usage(self, node)
+    }
+
+    fn visit_trait_usage_adaptation(&mut self, node: &TraitUsageAdaptation) {
+        walk_trait_usage_adaptation(self, node)
+    }
+
+    fn visit_property(&mut self, node: &Property) {
+        walk_property(self, node)
+    }
+
+    fn visit_property_entry(&mut self, node: &PropertyEntry) {
+        walk_property_entry(self, node)
+    }
+
+    fn visit_variable_property(&mut self, node: &VariableProperty) {
+        walk_variable_property(self, node)
+    }
+
+    fn visit_abstract_method(&mut self, node: &AbstractMethod) {
+        walk_abstract_method(self, node)
+    }
+
+    fn visit_abstract_constructor(&mut self, node: &AbstractConstructor) {
+        walk_abstract_constructor(self, node)
+    }
+
+    fn visit_constructor_parameter_list(&mut self, node: &ConstructorParameterList) {
+        walk_constructor_parameter_list(self, node)
+    }
+
+    fn visit_concrete_method(&mut self, node: &ConcreteMethod) {
+        walk_concrete_method(self, node)
+    }
+
+    fn visit_method_body(&mut self, node: &MethodBody) {
+        walk_method_body(self, node)
+    }
+
+    fn visit_constructor_parameter(&mut self, node: &ConstructorParameter) {
+        walk_constructor_parameter(self, node)
+    }
+
+    fn visit_concrete_constructor(&mut self, node: &ConcreteConstructor) {
+        walk_concrete_constructor(self, node)
+    }
+
+    fn visit_interface(&mut self, node: &InterfaceStatement) {
+        walk_interface(self, node)
+    }
+
+    fn visit_interface_extends(&mut self, node: &InterfaceExtends) {
+        walk_interface_extends(self, node)
+    }
+
+    fn visit_interface_body(&mut self, node: &InterfaceBody) {
+        walk_interface_body(self, node)
+    }
+
+    fn visit_trait(&mut self, node: &TraitStatement) {
+        walk_trait(self, node)
+    }
+
+    fn visit_trait_body(&mut self, node: &TraitBody) {
+        walk_trait_body(self, node)
+    }
+
+    fn visit_echo(&mut self, node: &EchoStatement) {
+        walk_echo(self, node)
+    }
+
+    fn visit_expression_stmt(&mut self, node: &ExpressionStatement) {
+        walk_expression_stmt(self, node)
+    }
+
+    fn visit_return(&mut self, node: &ReturnStatement) {
+        walk_return(self, node)
+    }
+
+    fn visit_namespace(&mut self, node: &NamespaceStatement) {
+        walk_namespace(self, node)
+    }
+
+    fn visit_unbraced_namespace(&mut self, node: &UnbracedNamespace) {
+        walk_unbraced_namespace(self, node)
+    }
+
+    fn visit_braced_namespace(&mut self, node: &BracedNamespace) {
+        walk_braced_namespace(self, node)
+    }
+
+    fn visit_use(&mut self, node: &UseStatement) {
+        walk_use(self, node)
+    }
+
+    fn visit_use_use(&mut self, node: &Use) {
+        walk_use_use(self, node)
+    }
+
+    fn visit_group_use(&mut self, node: &GroupUseStatement) {
+        walk_group_use(self, node)
+    }
+
+    fn visit_comment_stmt(&mut self, _: &Comment) {}
+
+    fn visit_try(&mut self, node: &TryStatement) {
+        walk_try(self, node)
+    }
+
+    fn visit_catch_block(&mut self, node: &CatchBlock) {
+        walk_catch_block(self, node)
+    }
+
+    fn visit_finally_block(&mut self, node: &FinallyBlock) {
+        walk_finally_block(self, node)
+    }
+
+    fn visit_unit_enum(&mut self, node: &UnitEnumStatement) {
+        walk_unit_enum(self, node)
+    }
+
+    fn visit_unit_enum_member(&mut self, node: &UnitEnumMember) {
+        walk_unit_enum_member(self, node)
+    }
+
+    fn visit_unit_enum_case(&mut self, node: &UnitEnumCase) {
+        walk_unit_enum_case(self, node)
+    }
+
+    fn visit_backed_enum(&mut self, node: &BackedEnumStatement) {
+        walk_backed_enum(self, node)
+    }
+
+    fn visit_backed_enum_member(&mut self, node: &BackedEnumMember) {
+        walk_backed_enum_member(self, node)
+    }
+
+    fn visit_backed_enum_case(&mut self, node: &BackedEnumCase) {
+        walk_backed_enum_case(self, node)
+    }
+
+    fn visit_block(&mut self, node: &BlockStatement) {
+        walk(self, &node.statements);
+    }
+
+    fn visit_declare(&mut self, node: &DeclareStatement) {
+        walk_declare(self, node)
+    }
+
+    fn visit_declare_entry(&mut self, node: &DeclareEntry) {
+        walk_declare_entry(self, node)
+    }
+
+    fn visit_declare_body(&mut self, node: &DeclareBody) {
+        walk_declare_body(self, node)
+    }
+
+    fn visit_noop(&mut self, _: Span) {}
+
+    fn visit_missing_expr(&mut self) {}
+
+    fn visit_argument_list(&mut self, node: &ArgumentList) {
+        walk_argument_list(self, node)
+    }
+
+    fn visit_argument(&mut self, node: &Argument) {
+        walk_argument(self, node)
+    }
+
+    fn visit_eval(&mut self, node: &EvalExpression) {
+        walk_eval(self, node)
+    }
+
+    fn visit_empty(&mut self, node: &EmptyExpression) {
+        walk_empty(self, node)
+    }
+
+    fn visit_die(&mut self, node: &DieExpression) {
+        walk_die(self, node)
+    }
+
+    fn visit_exit(&mut self, node: &ExitExpression) {
+        walk_exit(self, node)
+    }
+
+    fn visit_isset(&mut self, node: &IssetExpression) {
+        walk_isset(self, node)
+    }
+
+    fn visit_unset(&mut self, node: &UnsetExpression) {
+        walk_unset(self, node)
+    }
+
+    fn visit_print(&mut self, node: &PrintExpression) {
+        walk_print(self, node)
+    }
+
+    fn visit_literal(&mut self, _: &Literal) {}
+
+    fn visit_arithmetic_operation(&mut self, node: &ArithmeticOperationExpression) {
+        walk_arithmetic_operation(self, node)
+    }
+
+    fn visit_assignment_operation(&mut self, node: &AssignmentOperationExpression) {
+        walk_assignment_operation(self, node)
+    }
+
+    fn visit_bitwise_operation(&mut self, node: &BitwiseOperationExpression) {
+        walk_bitwise_operation(self, node)
+    }
+
+    fn visit_comparison_operation(&mut self, node: &ComparisonOperationExpression) {
+        walk_comparison_operation(self, node)
+    }
+
+    fn visit_logical_operation(&mut self, node: &LogicalOperationExpression) {
+        walk_logical_operation(self, node)
+    }
+
+    fn visit_concat(&mut self, node: &ConcatExpression) {
+        walk_concat(self, node)
+    }
+
+    fn visit_instanceof(&mut self, node: &InstanceofExpression) {
+        walk_instanceof(self, node)
+    }
+
+    fn visit_reference(&mut self, node: &ReferenceExpression) {
+        walk_reference(self, node)
+    }
+
+    fn visit_parenthesized(&mut self, node: &ParenthesizedExpression) {
+        walk_parenthesized(self, node)
+    }
+
+    fn visit_error_suppress(&mut self, node: &ErrorSuppressExpression) {
+        walk_error_suppress(self, node)
+    }
+
+    fn visit_identifier(&mut self, node: &Identifier) {
+        walk_identifier(self, node)
+    }
+
+    fn visit_simple_identifier(&mut self, _: &SimpleIdentifier) {}
+
+    fn visit_dynamic_identifier(&mut self, node: &DynamicIdentifier) {
+        walk_dynamic_identifier(self, node)
+    }
+
+    fn visit_variable(&mut self, node: &Variable) {
+        walk_variable(self, node)
+    }
+
+    fn visit_simple_variable(&mut self, _: &SimpleVariable) {}
+
+    fn visit_variable_variable(&mut self, node: &VariableVariable) {
+        walk_variable_variable(self, node);
+    }
+
+    fn visit_braced_variable_variable(&mut self, node: &BracedVariableVariable) {
+        walk_braced_variable_variable(self, node);
+    }
+
+    fn visit_include(&mut self, node: &IncludeExpression) {
+        walk_include(self, node);
+    }
+
+    fn visit_include_once(&mut self, node: &IncludeOnceExpression) {
+        walk_include_once(self, node);
+    }
+
+    fn visit_require(&mut self, node: &RequireExpression) {
+        walk_require(self, node);
+    }
+
+    fn visit_require_once(&mut self, node: &RequireOnceExpression) {
+        walk_require_once(self, node);
+    }
+
+    fn visit_function_call(&mut self, node: &FunctionCallExpression) {
+        walk_function_call(self, node);
+    }
+
+    fn visit_function_closure_creation(&mut self, node: &FunctionClosureCreationExpression) {
+        walk_function_closure_creation(self, node);
+    }
+
+    fn visit_method_call(&mut self, node: &MethodCallExpression) {
+        walk_method_call(self, node);
+    }
+
+    fn visit_method_closure_creation(&mut self, node: &MethodClosureCreationExpression) {
+        walk_method_closure_creation(self, node);
+    }
+
+    fn visit_nullsafe_method_call(&mut self, node: &NullsafeMethodCallExpression) {
+        walk_nullsafe_method_call(self, node);
+    }
+
+    fn visit_static_method_call(&mut self, node: &StaticMethodCallExpression) {
+        walk_static_method_call(self, node);
+    }
+
+    fn visit_static_variable_method_call(&mut self, node: &StaticVariableMethodCallExpression) {
+        walk_static_variable_method_call(self, node);
+    }
+
+    fn visit_static_method_closure_creation(
+        &mut self,
+        node: &StaticMethodClosureCreationExpression,
+    ) {
+        walk_static_method_closure_creation(self, node);
+    }
+
+    fn visit_static_variable_method_closure_creation(
+        &mut self,
+        node: &StaticVariableMethodClosureCreationExpression,
+    ) {
+        walk_static_variable_method_closure_creation(self, node);
+    }
+
+    fn visit_property_fetch(&mut self, node: &PropertyFetchExpression) {
+        walk_property_fetch(self, node);
+    }
+
+    fn visit_nullsafe_property_fetch(&mut self, node: &NullsafePropertyFetchExpression) {
+        walk_nullsafe_property_fetch(self, node);
+    }
+
+    fn visit_static_property_fetch(&mut self, node: &StaticPropertyFetchExpression) {
+        walk_static_property_fetch(self, node);
+    }
+
+    fn visit_constant_fetch(&mut self, node: &ConstantFetchExpression) {
+        walk_constant_fetch(self, node);
+    }
+
+    fn visit_static_expr(&mut self) {}
+    fn visit_self_expr(&mut self) {}
+    fn visit_parent_expr(&mut self) {}
+
+    fn visit_array_item(&mut self, node: &ArrayItem) {
+        walk_array_item(self, node);
+    }
+
+    fn visit_short_array(&mut self, node: &ShortArrayExpression) {
+        walk_short_array(self, node);
+    }
+
+    fn visit_array(&mut self, node: &ArrayExpression) {
+        walk_array(self, node);
+    }
+
+    fn visit_list(&mut self, node: &ListExpression) {
+        walk_list(self, node);
+    }
+
+    fn visit_list_entry(&mut self, node: &ListEntry) {
+        walk_list_entry(self, node);
+    }
+
+    fn visit_closure(&mut self, node: &ClosureExpression) {
+        walk_closure(self, node);
+    }
+
+    fn visit_arrow_function(&mut self, node: &ArrowFunctionExpression) {
+        walk_arrow_function(self, node);
+    }
+
+    fn visit_new(&mut self, node: &NewExpression) {
+        walk_new(self, node);
+    }
+
+    fn visit_interpolated_string(&mut self, node: &InterpolatedStringExpression) {
+        walk_interpolated_string(self, node);
+    }
+
+    fn visit_string_part(&mut self, node: &StringPart) {
+        walk_string_part(self, node);
+    }
+
+    fn visit_literal_string_part(&mut self, _: &LiteralStringPart) {}
+
+    fn visit_expression_string_part(&mut self, node: &ExpressionStringPart) {
+        walk_expression_string_part(self, node);
+    }
+
+    fn visit_heredoc(&mut self, node: &HeredocExpression) {
+        walk_heredoc(self, node);
+    }
+
+    fn visit_nowdoc(&mut self, _: &NowdocExpression) {}
+
+    fn visit_shell_exec(&mut self, node: &ShellExecExpression) {
+        walk_shell_exec(self, node);
+    }
+
+    fn visit_anonymous_class(&mut self, node: &AnonymousClassExpression) {
+        walk_anonymous_class(self, node);
+    }
+
+    fn visit_anonymous_class_body(&mut self, node: &AnonymousClassBody) {
+        walk_anonymous_class_body(self, node);
+    }
+
+    fn visit_bool(&mut self, _: &BoolExpression) {}
+
+    fn visit_array_index(&mut self, node: &ArrayIndexExpression) {
+        walk_array_index(self, node);
+    }
+
+    fn visit_null_expr(&mut self) {}
+
+    fn visit_magic_constant(&mut self, _: &MagicConstantExpression) {}
+
+    fn visit_short_ternary(&mut self, node: &ShortTernaryExpression) {
+        walk_short_ternary(self, node);
+    }
+
+    fn visit_ternary(&mut self, node: &TernaryExpression) {
+        walk_ternary(self, node);
+    }
+
+    fn visit_coalesce(&mut self, node: &CoalesceExpression) {
+        walk_coalesce(self, node);
+    }
+
+    fn visit_clone(&mut self, node: &CloneExpression) {
+        walk_clone(self, node);
+    }
+
+    fn visit_match(&mut self, node: &MatchExpression) {
+        walk_match(self, node);
+    }
+
+    fn visit_match_arm(&mut self, node: &MatchArm) {
+        walk_match_arm(self, node);
+    }
+
+    fn visit_default_match_arm(&mut self, node: &DefaultMatchArm) {
+        walk_default_match_arm(self, node);
+    }
+
+    fn visit_throw(&mut self, node: &ThrowExpression) {
+        walk_throw(self, node);
+    }
+
+    fn visit_yield(&mut self, node: &YieldExpression) {
+        walk_yield(self, node);
+    }
+
+    fn visit_yield_from(&mut self, node: &YieldFromExpression) {
+        walk_yield_from(self, node);
+    }
+
+    fn visit_cast(&mut self, node: &CastExpression) {
+        walk_cast(self, node);
+    }
+
+    fn visit_noop_expr(&mut self) {}
+
+    fn visit_return_type(&mut self, node: &ReturnType) {
+        walk_return_type(self, node);
+    }
+
+    fn visit_data_type(&mut self, node: &DataType) {
+        walk_data_type(self, node);
+    }
+
+    fn visit_type(&mut self, node: &Type) {
+        walk_type(self, node);
+    }
+}

--- a/crates/pxp-visitor/src/visitor.rs
+++ b/crates/pxp-visitor/src/visitor.rs
@@ -64,15 +64,15 @@ use pxp_type::Type;
 
 pub trait VisitorMut {
     fn visit(&mut self, node: &mut [Statement]) {
-        walk(self, node);
+        walk_mut(self, node);
     }
 
     fn visit_statement(&mut self, node: &mut Statement) {
-        walk_statement(self, node)
+        walk_statement_mut(self, node)
     }
 
     fn visit_expression(&mut self, node: &mut Expression) {
-        walk_expression(self, node)
+        walk_expression_mut(self, node)
     }
 
     fn visit_full_opening_tag(&mut self, _: &mut FullOpeningTagStatement) {}
@@ -84,309 +84,309 @@ pub trait VisitorMut {
     fn visit_halt_compiler(&mut self, _: &mut HaltCompilerStatement) {}
 
     fn visit_label(&mut self, node: &mut LabelStatement) {
-        walk_label(self, node)
+        walk_label_mut(self, node)
     }
 
     fn visit_goto(&mut self, node: &mut GotoStatement) {
-        walk_goto(self, node)
+        walk_goto_mut(self, node)
     }
 
     fn visit_static(&mut self, node: &mut StaticStatement) {
-        walk_static(self, node)
+        walk_static_mut(self, node)
     }
 
     fn visit_static_var(&mut self, var: &mut StaticVar) {
-        walk_static_var(self, var)
+        walk_static_var_mut(self, var)
     }
 
     fn visit_global(&mut self, node: &mut GlobalStatement) {
-        walk_global(self, node);
+        walk_global_mut(self, node);
     }
 
     fn visit_do_while(&mut self, node: &mut DoWhileStatement) {
-        walk_do_while(self, node)
+        walk_do_while_mut(self, node)
     }
 
     fn visit_while(&mut self, node: &mut WhileStatement) {
-        walk_while(self, node)
+        walk_while_mut(self, node)
     }
 
     fn visit_while_statement_body(&mut self, node: &mut WhileStatementBody) {
-        walk_while_statement_body(self, node)
+        walk_while_statement_body_mut(self, node)
     }
 
     fn visit_for(&mut self, node: &mut ForStatement) {
-        walk_for(self, node)
+        walk_for_mut(self, node)
     }
 
     fn visit_for_statement_iterator(&mut self, node: &mut ForStatementIterator) {
-        walk_for_statement_iterator(self, node);
+        walk_for_statement_iterator_mut(self, node);
     }
 
     fn visit_for_statement_body(&mut self, node: &mut ForStatementBody) {
-        walk_for_statement_body(self, node);
+        walk_for_statement_body_mut(self, node);
     }
 
     fn visit_foreach(&mut self, node: &mut ForeachStatement) {
-        walk_foreach(self, node)
+        walk_foreach_mut(self, node)
     }
 
     fn visit_foreach_statement_iterator(&mut self, node: &mut ForeachStatementIterator) {
-        walk_foreach_statement_iterator(self, node)
+        walk_foreach_statement_iterator_mut(self, node)
     }
 
     fn visit_foreach_statement_body(&mut self, node: &mut ForeachStatementBody) {
-        walk_foreach_statement_body(self, node)
+        walk_foreach_statement_body_mut(self, node)
     }
 
     fn visit_if(&mut self, node: &mut IfStatement) {
-        walk_if(self, node)
+        walk_if_mut(self, node)
     }
 
     fn visit_if_statement_body(&mut self, node: &mut IfStatementBody) {
-        walk_if_statement_body(self, node)
+        walk_if_statement_body_mut(self, node)
     }
 
     fn visit_if_statement_elseif(&mut self, node: &mut IfStatementElseIf) {
-        walk_if_statement_elseif(self, node)
+        walk_if_statement_elseif_mut(self, node)
     }
 
     fn visit_if_statement_else(&mut self, node: &mut IfStatementElse) {
-        walk_if_statement_else(self, node)
+        walk_if_statement_else_mut(self, node)
     }
 
     fn visit_if_statement_elseif_block(&mut self, node: &mut IfStatementElseIfBlock) {
-        walk_if_statement_elseif_block(self, node)
+        walk_if_statement_elseif_block_mut(self, node)
     }
 
     fn visit_if_statement_else_block(&mut self, node: &mut IfStatementElseBlock) {
-        walk_if_statement_else_block(self, node)
+        walk_if_statement_else_block_mut(self, node)
     }
 
     fn visit_switch(&mut self, node: &mut SwitchStatement) {
-        walk_switch(self, node)
+        walk_switch_mut(self, node)
     }
 
     fn visit_switch_case(&mut self, node: &mut Case) {
-        walk_switch_case(self, node)
+        walk_switch_case_mut(self, node)
     }
 
     fn visit_level(&mut self, node: &mut Level) {
-        walk_level(self, node)
+        walk_level_mut(self, node)
     }
 
     fn visit_break(&mut self, node: &mut BreakStatement) {
-        walk_break(self, node)
+        walk_break_mut(self, node)
     }
 
     fn visit_continue(&mut self, node: &mut ContinueStatement) {
-        walk_continue(self, node)
+        walk_continue_mut(self, node)
     }
 
     fn visit_constant(&mut self, node: &mut ConstantStatement) {
-        walk_constant(self, node)
+        walk_constant_mut(self, node)
     }
 
     fn visit_constant_entry(&mut self, node: &mut ConstantEntry) {
-        walk_constant_entry(self, node)
+        walk_constant_entry_mut(self, node)
     }
 
     fn visit_function(&mut self, node: &mut FunctionStatement) {
-        walk_function(self, node)
+        walk_function_mut(self, node)
     }
 
     fn visit_function_parameter_list(&mut self, node: &mut FunctionParameterList) {
-        walk_function_parameter_list(self, node)
+        walk_function_parameter_list_mut(self, node)
     }
 
     fn visit_function_parameter(&mut self, node: &mut FunctionParameter) {
-        walk_function_parameter(self, node)
+        walk_function_parameter_mut(self, node)
     }
 
     fn visit_function_body(&mut self, node: &mut FunctionBody) {
-        walk_function_body(self, node)
+        walk_function_body_mut(self, node)
     }
 
     fn visit_class(&mut self, node: &mut ClassStatement) {
-        walk_class(self, node)
+        walk_class_mut(self, node)
     }
 
     fn visit_class_extends(&mut self, node: &mut ClassExtends) {
-        walk_class_extends(self, node)
+        walk_class_extends_mut(self, node)
     }
 
     fn visit_class_implements(&mut self, node: &mut ClassImplements) {
-        walk_class_implements(self, node)
+        walk_class_implements_mut(self, node)
     }
 
     fn visit_class_body(&mut self, node: &mut ClassBody) {
-        walk_class_body(self, node)
+        walk_class_body_mut(self, node)
     }
 
     fn visit_classish_member(&mut self, node: &mut ClassishMember) {
-        walk_classish_member(self, node)
+        walk_classish_member_mut(self, node)
     }
 
     fn visit_classish_constant(&mut self, node: &mut ClassishConstant) {
-        walk_classish_constant(self, node)
+        walk_classish_constant_mut(self, node)
     }
 
     fn visit_trait_usage(&mut self, node: &mut TraitUsage) {
-        walk_trait_usage(self, node)
+        walk_trait_usage_mut(self, node)
     }
 
     fn visit_trait_usage_adaptation(&mut self, node: &mut TraitUsageAdaptation) {
-        walk_trait_usage_adaptation(self, node)
+        walk_trait_usage_adaptation_mut(self, node)
     }
 
     fn visit_property(&mut self, node: &mut Property) {
-        walk_property(self, node)
+        walk_property_mut(self, node)
     }
 
     fn visit_property_entry(&mut self, node: &mut PropertyEntry) {
-        walk_property_entry(self, node)
+        walk_property_entry_mut(self, node)
     }
 
     fn visit_variable_property(&mut self, node: &mut VariableProperty) {
-        walk_variable_property(self, node)
+        walk_variable_property_mut(self, node)
     }
 
     fn visit_abstract_method(&mut self, node: &mut AbstractMethod) {
-        walk_abstract_method(self, node)
+        walk_abstract_method_mut(self, node)
     }
 
     fn visit_abstract_constructor(&mut self, node: &mut AbstractConstructor) {
-        walk_abstract_constructor(self, node)
+        walk_abstract_constructor_mut(self, node)
     }
 
     fn visit_constructor_parameter_list(&mut self, node: &mut ConstructorParameterList) {
-        walk_constructor_parameter_list(self, node)
+        walk_constructor_parameter_list_mut(self, node)
     }
 
     fn visit_concrete_method(&mut self, node: &mut ConcreteMethod) {
-        walk_concrete_method(self, node)
+        walk_concrete_method_mut(self, node)
     }
 
     fn visit_method_body(&mut self, node: &mut MethodBody) {
-        walk_method_body(self, node)
+        walk_method_body_mut(self, node)
     }
 
     fn visit_constructor_parameter(&mut self, node: &mut ConstructorParameter) {
-        walk_constructor_parameter(self, node)
+        walk_constructor_parameter_mut(self, node)
     }
 
     fn visit_concrete_constructor(&mut self, node: &mut ConcreteConstructor) {
-        walk_concrete_constructor(self, node)
+        walk_concrete_constructor_mut(self, node)
     }
 
     fn visit_interface(&mut self, node: &mut InterfaceStatement) {
-        walk_interface(self, node)
+        walk_interface_mut(self, node)
     }
 
     fn visit_interface_extends(&mut self, node: &mut InterfaceExtends) {
-        walk_interface_extends(self, node)
+        walk_interface_extends_mut(self, node)
     }
 
     fn visit_interface_body(&mut self, node: &mut InterfaceBody) {
-        walk_interface_body(self, node)
+        walk_interface_body_mut(self, node)
     }
 
     fn visit_trait(&mut self, node: &mut TraitStatement) {
-        walk_trait(self, node)
+        walk_trait_mut(self, node)
     }
 
     fn visit_trait_body(&mut self, node: &mut TraitBody) {
-        walk_trait_body(self, node)
+        walk_trait_body_mut(self, node)
     }
 
     fn visit_echo(&mut self, node: &mut EchoStatement) {
-        walk_echo(self, node)
+        walk_echo_mut(self, node)
     }
 
     fn visit_expression_stmt(&mut self, node: &mut ExpressionStatement) {
-        walk_expression_stmt(self, node)
+        walk_expression_stmt_mut(self, node)
     }
 
     fn visit_return(&mut self, node: &mut ReturnStatement) {
-        walk_return(self, node)
+        walk_return_mut(self, node)
     }
 
     fn visit_namespace(&mut self, node: &mut NamespaceStatement) {
-        walk_namespace(self, node)
+        walk_namespace_mut(self, node)
     }
 
     fn visit_unbraced_namespace(&mut self, node: &mut UnbracedNamespace) {
-        walk_unbraced_namespace(self, node)
+        walk_unbraced_namespace_mut(self, node)
     }
 
     fn visit_braced_namespace(&mut self, node: &mut BracedNamespace) {
-        walk_braced_namespace(self, node)
+        walk_braced_namespace_mut(self, node)
     }
 
     fn visit_use(&mut self, node: &mut UseStatement) {
-        walk_use(self, node)
+        walk_use_mut(self, node)
     }
 
     fn visit_use_use(&mut self, node: &mut Use) {
-        walk_use_use(self, node)
+        walk_use_use_mut(self, node)
     }
 
     fn visit_group_use(&mut self, node: &mut GroupUseStatement) {
-        walk_group_use(self, node)
+        walk_group_use_mut(self, node)
     }
 
     fn visit_comment_stmt(&mut self, _: &mut Comment) {}
 
     fn visit_try(&mut self, node: &mut TryStatement) {
-        walk_try(self, node)
+        walk_try_mut(self, node)
     }
 
     fn visit_catch_block(&mut self, node: &mut CatchBlock) {
-        walk_catch_block(self, node)
+        walk_catch_block_mut(self, node)
     }
 
     fn visit_finally_block(&mut self, node: &mut FinallyBlock) {
-        walk_finally_block(self, node)
+        walk_finally_block_mut(self, node)
     }
 
     fn visit_unit_enum(&mut self, node: &mut UnitEnumStatement) {
-        walk_unit_enum(self, node)
+        walk_unit_enum_mut(self, node)
     }
 
     fn visit_unit_enum_member(&mut self, node: &mut UnitEnumMember) {
-        walk_unit_enum_member(self, node)
+        walk_unit_enum_member_mut(self, node)
     }
 
     fn visit_unit_enum_case(&mut self, node: &mut UnitEnumCase) {
-        walk_unit_enum_case(self, node)
+        walk_unit_enum_case_mut(self, node)
     }
 
     fn visit_backed_enum(&mut self, node: &mut BackedEnumStatement) {
-        walk_backed_enum(self, node)
+        walk_backed_enum_mut(self, node)
     }
 
     fn visit_backed_enum_member(&mut self, node: &mut BackedEnumMember) {
-        walk_backed_enum_member(self, node)
+        walk_backed_enum_member_mut(self, node)
     }
 
     fn visit_backed_enum_case(&mut self, node: &mut BackedEnumCase) {
-        walk_backed_enum_case(self, node)
+        walk_backed_enum_case_mut(self, node)
     }
 
     fn visit_block(&mut self, node: &mut BlockStatement) {
-        walk(self, &mut node.statements);
+        walk_mut(self, &mut node.statements);
     }
 
     fn visit_declare(&mut self, node: &mut DeclareStatement) {
-        walk_declare(self, node)
+        walk_declare_mut(self, node)
     }
 
     fn visit_declare_entry(&mut self, node: &mut DeclareEntry) {
-        walk_declare_entry(self, node)
+        walk_declare_entry_mut(self, node)
     }
 
     fn visit_declare_body(&mut self, node: &mut DeclareBody) {
-        walk_declare_body(self, node)
+        walk_declare_body_mut(self, node)
     }
 
     fn visit_noop(&mut self, _: Span) {}
@@ -394,179 +394,179 @@ pub trait VisitorMut {
     fn visit_missing_expr(&mut self) {}
 
     fn visit_argument_list(&mut self, node: &mut ArgumentList) {
-        walk_argument_list(self, node)
+        walk_argument_list_mut(self, node)
     }
 
     fn visit_argument(&mut self, node: &mut Argument) {
-        walk_argument(self, node)
+        walk_argument_mut(self, node)
     }
 
     fn visit_eval(&mut self, node: &mut EvalExpression) {
-        walk_eval(self, node)
+        walk_eval_mut(self, node)
     }
 
     fn visit_empty(&mut self, node: &mut EmptyExpression) {
-        walk_empty(self, node)
+        walk_empty_mut(self, node)
     }
 
     fn visit_die(&mut self, node: &mut DieExpression) {
-        walk_die(self, node)
+        walk_die_mut(self, node)
     }
 
     fn visit_exit(&mut self, node: &mut ExitExpression) {
-        walk_exit(self, node)
+        walk_exit_mut(self, node)
     }
 
     fn visit_isset(&mut self, node: &mut IssetExpression) {
-        walk_isset(self, node)
+        walk_isset_mut(self, node)
     }
 
     fn visit_unset(&mut self, node: &mut UnsetExpression) {
-        walk_unset(self, node)
+        walk_unset_mut(self, node)
     }
 
     fn visit_print(&mut self, node: &mut PrintExpression) {
-        walk_print(self, node)
+        walk_print_mut(self, node)
     }
 
     fn visit_literal(&mut self, _: &mut Literal) {}
 
     fn visit_arithmetic_operation(&mut self, node: &mut ArithmeticOperationExpression) {
-        walk_arithmetic_operation(self, node)
+        walk_arithmetic_operation_mut(self, node)
     }
 
     fn visit_assignment_operation(&mut self, node: &mut AssignmentOperationExpression) {
-        walk_assignment_operation(self, node)
+        walk_assignment_operation_mut(self, node)
     }
 
     fn visit_bitwise_operation(&mut self, node: &mut BitwiseOperationExpression) {
-        walk_bitwise_operation(self, node)
+        walk_bitwise_operation_mut(self, node)
     }
 
     fn visit_comparison_operation(&mut self, node: &mut ComparisonOperationExpression) {
-        walk_comparison_operation(self, node)
+        walk_comparison_operation_mut(self, node)
     }
 
     fn visit_logical_operation(&mut self, node: &mut LogicalOperationExpression) {
-        walk_logical_operation(self, node)
+        walk_logical_operation_mut(self, node)
     }
 
     fn visit_concat(&mut self, node: &mut ConcatExpression) {
-        walk_concat(self, node)
+        walk_concat_mut(self, node)
     }
 
     fn visit_instanceof(&mut self, node: &mut InstanceofExpression) {
-        walk_instanceof(self, node)
+        walk_instanceof_mut(self, node)
     }
 
     fn visit_reference(&mut self, node: &mut ReferenceExpression) {
-        walk_reference(self, node)
+        walk_reference_mut(self, node)
     }
 
     fn visit_parenthesized(&mut self, node: &mut ParenthesizedExpression) {
-        walk_parenthesized(self, node)
+        walk_parenthesized_mut(self, node)
     }
 
     fn visit_error_suppress(&mut self, node: &mut ErrorSuppressExpression) {
-        walk_error_suppress(self, node)
+        walk_error_suppress_mut(self, node)
     }
 
     fn visit_identifier(&mut self, node: &mut Identifier) {
-        walk_identifier(self, node)
+        walk_identifier_mut(self, node)
     }
 
     fn visit_simple_identifier(&mut self, _: &mut SimpleIdentifier) {}
 
     fn visit_dynamic_identifier(&mut self, node: &mut DynamicIdentifier) {
-        walk_dynamic_identifier(self, node)
+        walk_dynamic_identifier_mut(self, node)
     }
 
     fn visit_variable(&mut self, node: &mut Variable) {
-        walk_variable(self, node)
+        walk_variable_mut(self, node)
     }
 
     fn visit_simple_variable(&mut self, _: &mut SimpleVariable) {}
 
     fn visit_variable_variable(&mut self, node: &mut VariableVariable) {
-        walk_variable_variable(self, node);
+        walk_variable_variable_mut(self, node);
     }
 
     fn visit_braced_variable_variable(&mut self, node: &mut BracedVariableVariable) {
-        walk_braced_variable_variable(self, node);
+        walk_braced_variable_variable_mut(self, node);
     }
 
     fn visit_include(&mut self, node: &mut IncludeExpression) {
-        walk_include(self, node);
+        walk_include_mut(self, node);
     }
 
     fn visit_include_once(&mut self, node: &mut IncludeOnceExpression) {
-        walk_include_once(self, node);
+        walk_include_once_mut(self, node);
     }
 
     fn visit_require(&mut self, node: &mut RequireExpression) {
-        walk_require(self, node);
+        walk_require_mut(self, node);
     }
 
     fn visit_require_once(&mut self, node: &mut RequireOnceExpression) {
-        walk_require_once(self, node);
+        walk_require_once_mut(self, node);
     }
 
     fn visit_function_call(&mut self, node: &mut FunctionCallExpression) {
-        walk_function_call(self, node);
+        walk_function_call_mut(self, node);
     }
 
     fn visit_function_closure_creation(&mut self, node: &mut FunctionClosureCreationExpression) {
-        walk_function_closure_creation(self, node);
+        walk_function_closure_creation_mut(self, node);
     }
 
     fn visit_method_call(&mut self, node: &mut MethodCallExpression) {
-        walk_method_call(self, node);
+        walk_method_call_mut(self, node);
     }
 
     fn visit_method_closure_creation(&mut self, node: &mut MethodClosureCreationExpression) {
-        walk_method_closure_creation(self, node);
+        walk_method_closure_creation_mut(self, node);
     }
 
     fn visit_nullsafe_method_call(&mut self, node: &mut NullsafeMethodCallExpression) {
-        walk_nullsafe_method_call(self, node);
+        walk_nullsafe_method_call_mut(self, node);
     }
 
     fn visit_static_method_call(&mut self, node: &mut StaticMethodCallExpression) {
-        walk_static_method_call(self, node);
+        walk_static_method_call_mut(self, node);
     }
 
     fn visit_static_variable_method_call(&mut self, node: &mut StaticVariableMethodCallExpression) {
-        walk_static_variable_method_call(self, node);
+        walk_static_variable_method_call_mut(self, node);
     }
 
     fn visit_static_method_closure_creation(
         &mut self,
         node: &mut StaticMethodClosureCreationExpression,
     ) {
-        walk_static_method_closure_creation(self, node);
+        walk_static_method_closure_creation_mut(self, node);
     }
 
     fn visit_static_variable_method_closure_creation(
         &mut self,
         node: &mut StaticVariableMethodClosureCreationExpression,
     ) {
-        walk_static_variable_method_closure_creation(self, node);
+        walk_static_variable_method_closure_creation_mut(self, node);
     }
 
     fn visit_property_fetch(&mut self, node: &mut PropertyFetchExpression) {
-        walk_property_fetch(self, node);
+        walk_property_fetch_mut(self, node);
     }
 
     fn visit_nullsafe_property_fetch(&mut self, node: &mut NullsafePropertyFetchExpression) {
-        walk_nullsafe_property_fetch(self, node);
+        walk_nullsafe_property_fetch_mut(self, node);
     }
 
     fn visit_static_property_fetch(&mut self, node: &mut StaticPropertyFetchExpression) {
-        walk_static_property_fetch(self, node);
+        walk_static_property_fetch_mut(self, node);
     }
 
     fn visit_constant_fetch(&mut self, node: &mut ConstantFetchExpression) {
-        walk_constant_fetch(self, node);
+        walk_constant_fetch_mut(self, node);
     }
 
     fn visit_static_expr(&mut self) {}
@@ -574,73 +574,73 @@ pub trait VisitorMut {
     fn visit_parent_expr(&mut self) {}
 
     fn visit_array_item(&mut self, node: &mut ArrayItem) {
-        walk_array_item(self, node);
+        walk_array_item_mut(self, node);
     }
 
     fn visit_short_array(&mut self, node: &mut ShortArrayExpression) {
-        walk_short_array(self, node);
+        walk_short_array_mut(self, node);
     }
 
     fn visit_array(&mut self, node: &mut ArrayExpression) {
-        walk_array(self, node);
+        walk_array_mut(self, node);
     }
 
     fn visit_list(&mut self, node: &mut ListExpression) {
-        walk_list(self, node);
+        walk_list_mut(self, node);
     }
 
     fn visit_list_entry(&mut self, node: &mut ListEntry) {
-        walk_list_entry(self, node);
+        walk_list_entry_mut(self, node);
     }
 
     fn visit_closure(&mut self, node: &mut ClosureExpression) {
-        walk_closure(self, node);
+        walk_closure_mut(self, node);
     }
 
     fn visit_arrow_function(&mut self, node: &mut ArrowFunctionExpression) {
-        walk_arrow_function(self, node);
+        walk_arrow_function_mut(self, node);
     }
 
     fn visit_new(&mut self, node: &mut NewExpression) {
-        walk_new(self, node);
+        walk_new_mut(self, node);
     }
 
     fn visit_interpolated_string(&mut self, node: &mut InterpolatedStringExpression) {
-        walk_interpolated_string(self, node);
+        walk_interpolated_string_mut(self, node);
     }
 
     fn visit_string_part(&mut self, node: &mut StringPart) {
-        walk_string_part(self, node);
+        walk_string_part_mut(self, node);
     }
 
     fn visit_literal_string_part(&mut self, _: &mut LiteralStringPart) {}
 
     fn visit_expression_string_part(&mut self, node: &mut ExpressionStringPart) {
-        walk_expression_string_part(self, node);
+        walk_expression_string_part_mut(self, node);
     }
 
     fn visit_heredoc(&mut self, node: &mut HeredocExpression) {
-        walk_heredoc(self, node);
+        walk_heredoc_mut(self, node);
     }
 
     fn visit_nowdoc(&mut self, _: &mut NowdocExpression) {}
 
     fn visit_shell_exec(&mut self, node: &mut ShellExecExpression) {
-        walk_shell_exec(self, node);
+        walk_shell_exec_mut(self, node);
     }
 
     fn visit_anonymous_class(&mut self, node: &mut AnonymousClassExpression) {
-        walk_anonymous_class(self, node);
+        walk_anonymous_class_mut(self, node);
     }
 
     fn visit_anonymous_class_body(&mut self, node: &mut AnonymousClassBody) {
-        walk_anonymous_class_body(self, node);
+        walk_anonymous_class_body_mut(self, node);
     }
 
     fn visit_bool(&mut self, _: &mut BoolExpression) {}
 
     fn visit_array_index(&mut self, node: &mut ArrayIndexExpression) {
-        walk_array_index(self, node);
+        walk_array_index_mut(self, node);
     }
 
     fn visit_null_expr(&mut self) {}
@@ -648,60 +648,60 @@ pub trait VisitorMut {
     fn visit_magic_constant(&mut self, _: &mut MagicConstantExpression) {}
 
     fn visit_short_ternary(&mut self, node: &mut ShortTernaryExpression) {
-        walk_short_ternary(self, node);
+        walk_short_ternary_mut(self, node);
     }
 
     fn visit_ternary(&mut self, node: &mut TernaryExpression) {
-        walk_ternary(self, node);
+        walk_ternary_mut(self, node);
     }
 
     fn visit_coalesce(&mut self, node: &mut CoalesceExpression) {
-        walk_coalesce(self, node);
+        walk_coalesce_mut(self, node);
     }
 
     fn visit_clone(&mut self, node: &mut CloneExpression) {
-        walk_clone(self, node);
+        walk_clone_mut(self, node);
     }
 
     fn visit_match(&mut self, node: &mut MatchExpression) {
-        walk_match(self, node);
+        walk_match_mut(self, node);
     }
 
     fn visit_match_arm(&mut self, node: &mut MatchArm) {
-        walk_match_arm(self, node);
+        walk_match_arm_mut(self, node);
     }
 
     fn visit_default_match_arm(&mut self, node: &mut DefaultMatchArm) {
-        walk_default_match_arm(self, node);
+        walk_default_match_arm_mut(self, node);
     }
 
     fn visit_throw(&mut self, node: &mut ThrowExpression) {
-        walk_throw(self, node);
+        walk_throw_mut(self, node);
     }
 
     fn visit_yield(&mut self, node: &mut YieldExpression) {
-        walk_yield(self, node);
+        walk_yield_mut(self, node);
     }
 
     fn visit_yield_from(&mut self, node: &mut YieldFromExpression) {
-        walk_yield_from(self, node);
+        walk_yield_from_mut(self, node);
     }
 
     fn visit_cast(&mut self, node: &mut CastExpression) {
-        walk_cast(self, node);
+        walk_cast_mut(self, node);
     }
 
     fn visit_noop_expr(&mut self) {}
 
     fn visit_return_type(&mut self, node: &mut ReturnType) {
-        walk_return_type(self, node);
+        walk_return_type_mut(self, node);
     }
 
     fn visit_data_type(&mut self, node: &mut DataType) {
-        walk_data_type(self, node);
+        walk_data_type_mut(self, node);
     }
 
     fn visit_type(&mut self, node: &mut Type) {
-        walk_type(self, node);
+        walk_type_mut(self, node);
     }
 }

--- a/crates/pxp-visitor/src/visitor.rs
+++ b/crates/pxp-visitor/src/visitor.rs
@@ -62,7 +62,7 @@ use pxp_span::Span;
 use pxp_syntax::comments::Comment;
 use pxp_type::Type;
 
-pub trait Visitor {
+pub trait VisitorMut {
     fn visit(&mut self, node: &mut [Statement]) {
         walk(self, node);
     }

--- a/crates/pxp-visitor/src/walk.rs
+++ b/crates/pxp-visitor/src/walk.rs
@@ -55,15 +55,15 @@ use pxp_ast::{
 };
 use pxp_type::Type;
 
-use crate::Visitor;
+use crate::VisitorMut;
 
-pub fn walk<V: Visitor + ?Sized>(visitor: &mut V, program: &mut [Statement]) {
+pub fn walk<V: VisitorMut + ?Sized>(visitor: &mut V, program: &mut [Statement]) {
     for statement in program.iter_mut() {
         visitor.visit_statement(statement);
     }
 }
 
-pub fn walk_statement<V: Visitor + ?Sized>(visitor: &mut V, statement: &mut Statement) {
+pub fn walk_statement<V: VisitorMut + ?Sized>(visitor: &mut V, statement: &mut Statement) {
     match &mut statement.kind {
         StatementKind::FullOpeningTag(stmt) => visitor.visit_full_opening_tag(stmt),
         StatementKind::ShortOpeningTag(stmt) => visitor.visit_short_opening_tag(stmt),
@@ -104,7 +104,7 @@ pub fn walk_statement<V: Visitor + ?Sized>(visitor: &mut V, statement: &mut Stat
     };
 }
 
-pub fn walk_expression<V: Visitor + ?Sized>(visitor: &mut V, expression: &mut Expression) {
+pub fn walk_expression<V: VisitorMut + ?Sized>(visitor: &mut V, expression: &mut Expression) {
     match &mut expression.kind {
         ExpressionKind::Missing => visitor.visit_missing_expr(),
         ExpressionKind::Eval(expr) => visitor.visit_eval(expr),
@@ -190,7 +190,7 @@ macro_rules! walk {
         $($label:ident: $node:ty => $body:block )+
     ) => {
         $(
-            pub fn $label<V: Visitor + ?Sized>($v: &mut V, $n: &mut $node) $body
+            pub fn $label<V: VisitorMut + ?Sized>($v: &mut V, $n: &mut $node) $body
         )+
     }
 }

--- a/crates/pxp-visitor/src/walk.rs
+++ b/crates/pxp-visitor/src/walk.rs
@@ -56,7 +56,7 @@ use pxp_ast::{
 };
 use pxp_type::Type;
 
-use crate::VisitorMut;
+use crate::{VisitorMut, Visitor};
 
 pub fn walk_mut<V: VisitorMut + ?Sized>(visitor: &mut V, program: &mut [Statement]) {
     for statement in program.iter_mut() {
@@ -184,7 +184,133 @@ pub fn walk_expression_mut<V: VisitorMut + ?Sized>(visitor: &mut V, expression: 
     }
 }
 
-macro_rules! walk {
+pub fn walk<V: Visitor + ?Sized>(visitor: &mut V, program: &[Statement]) {
+    for statement in program.iter() {
+        visitor.visit_statement(statement);
+    }
+}
+
+pub fn walk_statement<V: Visitor + ?Sized>(visitor: &mut V, statement: &Statement) {
+    match &statement.kind {
+        StatementKind::FullOpeningTag(stmt) => visitor.visit_full_opening_tag(stmt),
+        StatementKind::ShortOpeningTag(stmt) => visitor.visit_short_opening_tag(stmt),
+        StatementKind::EchoOpeningTag(stmt) => visitor.visit_echo_opening_tag(stmt),
+        StatementKind::ClosingTag(stmt) => visitor.visit_closing_tag(stmt),
+        StatementKind::InlineHtml(stmt) => visitor.visit_inline_html(stmt),
+        StatementKind::Label(stmt) => visitor.visit_label(stmt),
+        StatementKind::Goto(stmt) => visitor.visit_goto(stmt),
+        StatementKind::HaltCompiler(stmt) => visitor.visit_halt_compiler(stmt),
+        StatementKind::Static(stmt) => visitor.visit_static(stmt),
+        StatementKind::DoWhile(stmt) => visitor.visit_do_while(stmt),
+        StatementKind::While(stmt) => visitor.visit_while(stmt),
+        StatementKind::For(stmt) => visitor.visit_for(stmt),
+        StatementKind::Foreach(stmt) => visitor.visit_foreach(stmt),
+        StatementKind::Break(stmt) => visitor.visit_break(stmt),
+        StatementKind::Continue(stmt) => visitor.visit_continue(stmt),
+        StatementKind::Constant(stmt) => visitor.visit_constant(stmt),
+        StatementKind::Function(stmt) => visitor.visit_function(stmt),
+        StatementKind::Class(stmt) => visitor.visit_class(stmt),
+        StatementKind::Trait(stmt) => visitor.visit_trait(stmt),
+        StatementKind::Interface(stmt) => visitor.visit_interface(stmt),
+        StatementKind::If(stmt) => visitor.visit_if(stmt),
+        StatementKind::Switch(stmt) => visitor.visit_switch(stmt),
+        StatementKind::Echo(stmt) => visitor.visit_echo(stmt),
+        StatementKind::Expression(stmt) => visitor.visit_expression_stmt(stmt),
+        StatementKind::Return(stmt) => visitor.visit_return(stmt),
+        StatementKind::Namespace(stmt) => visitor.visit_namespace(stmt),
+        StatementKind::Use(stmt) => visitor.visit_use(stmt),
+        StatementKind::GroupUse(stmt) => visitor.visit_group_use(stmt),
+        StatementKind::Comment(stmt) => visitor.visit_comment_stmt(stmt),
+        StatementKind::Try(stmt) => visitor.visit_try(stmt),
+        StatementKind::UnitEnum(stmt) => visitor.visit_unit_enum(stmt),
+        StatementKind::BackedEnum(stmt) => visitor.visit_backed_enum(stmt),
+        StatementKind::Block(stmt) => visitor.visit_block(stmt),
+        StatementKind::Global(stmt) => visitor.visit_global(stmt),
+        StatementKind::Declare(stmt) => visitor.visit_declare(stmt),
+        StatementKind::Noop(span) => visitor.visit_noop(*span),
+    };
+}
+
+pub fn walk_expression<V: Visitor + ?Sized>(visitor: &mut V, expression: &Expression) {
+    match &expression.kind {
+        ExpressionKind::Missing => visitor.visit_missing_expr(),
+        ExpressionKind::Eval(expr) => visitor.visit_eval(expr),
+        ExpressionKind::Empty(expr) => visitor.visit_empty(expr),
+        ExpressionKind::Die(expr) => visitor.visit_die(expr),
+        ExpressionKind::Exit(expr) => visitor.visit_exit(expr),
+        ExpressionKind::Isset(expr) => visitor.visit_isset(expr),
+        ExpressionKind::Unset(expr) => visitor.visit_unset(expr),
+        ExpressionKind::Print(expr) => visitor.visit_print(expr),
+        ExpressionKind::Literal(expr) => visitor.visit_literal(expr),
+        ExpressionKind::ArithmeticOperation(expr) => visitor.visit_arithmetic_operation(expr),
+        ExpressionKind::AssignmentOperation(expr) => visitor.visit_assignment_operation(expr),
+        ExpressionKind::BitwiseOperation(expr) => visitor.visit_bitwise_operation(expr),
+        ExpressionKind::ComparisonOperation(expr) => visitor.visit_comparison_operation(expr),
+        ExpressionKind::LogicalOperation(expr) => visitor.visit_logical_operation(expr),
+        ExpressionKind::Concat(expr) => visitor.visit_concat(expr),
+        ExpressionKind::Instanceof(expr) => visitor.visit_instanceof(expr),
+        ExpressionKind::Reference(expr) => visitor.visit_reference(expr),
+        ExpressionKind::Parenthesized(expr) => visitor.visit_parenthesized(expr),
+        ExpressionKind::ErrorSuppress(expr) => visitor.visit_error_suppress(expr),
+        ExpressionKind::Identifier(expr) => visitor.visit_identifier(expr),
+        ExpressionKind::Variable(expr) => visitor.visit_variable(expr),
+        ExpressionKind::Include(expr) => visitor.visit_include(expr),
+        ExpressionKind::IncludeOnce(expr) => visitor.visit_include_once(expr),
+        ExpressionKind::Require(expr) => visitor.visit_require(expr),
+        ExpressionKind::RequireOnce(expr) => visitor.visit_require_once(expr),
+        ExpressionKind::FunctionCall(expr) => visitor.visit_function_call(expr),
+        ExpressionKind::FunctionClosureCreation(expr) => {
+            visitor.visit_function_closure_creation(expr)
+        }
+        ExpressionKind::MethodCall(expr) => visitor.visit_method_call(expr),
+        ExpressionKind::MethodClosureCreation(expr) => visitor.visit_method_closure_creation(expr),
+        ExpressionKind::NullsafeMethodCall(expr) => visitor.visit_nullsafe_method_call(expr),
+        ExpressionKind::StaticMethodCall(expr) => visitor.visit_static_method_call(expr),
+        ExpressionKind::StaticVariableMethodCall(expr) => {
+            visitor.visit_static_variable_method_call(expr)
+        }
+        ExpressionKind::StaticMethodClosureCreation(expr) => {
+            visitor.visit_static_method_closure_creation(expr)
+        }
+        ExpressionKind::StaticVariableMethodClosureCreation(expr) => {
+            visitor.visit_static_variable_method_closure_creation(expr)
+        }
+        ExpressionKind::PropertyFetch(expr) => visitor.visit_property_fetch(expr),
+        ExpressionKind::NullsafePropertyFetch(expr) => visitor.visit_nullsafe_property_fetch(expr),
+        ExpressionKind::StaticPropertyFetch(expr) => visitor.visit_static_property_fetch(expr),
+        ExpressionKind::ConstantFetch(expr) => visitor.visit_constant_fetch(expr),
+        ExpressionKind::Static => visitor.visit_static_expr(),
+        ExpressionKind::Self_ => visitor.visit_self_expr(),
+        ExpressionKind::Parent => visitor.visit_parent_expr(),
+        ExpressionKind::ShortArray(expr) => visitor.visit_short_array(expr),
+        ExpressionKind::Array(expr) => visitor.visit_array(expr),
+        ExpressionKind::List(expr) => visitor.visit_list(expr),
+        ExpressionKind::Closure(expr) => visitor.visit_closure(expr),
+        ExpressionKind::ArrowFunction(expr) => visitor.visit_arrow_function(expr),
+        ExpressionKind::New(expr) => visitor.visit_new(expr),
+        ExpressionKind::InterpolatedString(expr) => visitor.visit_interpolated_string(expr),
+        ExpressionKind::Heredoc(expr) => visitor.visit_heredoc(expr),
+        ExpressionKind::Nowdoc(expr) => visitor.visit_nowdoc(expr),
+        ExpressionKind::ShellExec(expr) => visitor.visit_shell_exec(expr),
+        ExpressionKind::AnonymousClass(expr) => visitor.visit_anonymous_class(expr),
+        ExpressionKind::Bool(expr) => visitor.visit_bool(expr),
+        ExpressionKind::ArrayIndex(expr) => visitor.visit_array_index(expr),
+        ExpressionKind::Null => visitor.visit_null_expr(),
+        ExpressionKind::MagicConstant(expr) => visitor.visit_magic_constant(expr),
+        ExpressionKind::ShortTernary(expr) => visitor.visit_short_ternary(expr),
+        ExpressionKind::Ternary(expr) => visitor.visit_ternary(expr),
+        ExpressionKind::Coalesce(expr) => visitor.visit_coalesce(expr),
+        ExpressionKind::Clone(expr) => visitor.visit_clone(expr),
+        ExpressionKind::Match(expr) => visitor.visit_match(expr),
+        ExpressionKind::Throw(expr) => visitor.visit_throw(expr),
+        ExpressionKind::Yield(expr) => visitor.visit_yield(expr),
+        ExpressionKind::YieldFrom(expr) => visitor.visit_yield_from(expr),
+        ExpressionKind::Cast(expr) => visitor.visit_cast(expr),
+        ExpressionKind::Noop => visitor.visit_noop_expr(),
+    }
+}
+
+macro_rules! walk_mut {
     (
         using($v:ident, $n:ident);
 
@@ -198,7 +324,19 @@ macro_rules! walk {
     }
 }
 
-walk! {
+macro_rules! walk {
+    (
+        using($v:ident, $n:ident);
+
+        $($label:ident: $node:ty => $body:block )+
+    ) => {
+        $(
+            pub fn $label<V: Visitor + ?Sized>($v: &mut V, $n: &$node) $body
+        )+
+    }
+}
+
+walk_mut! {
     using(visitor, node);
 
     walk_label: LabelStatement => {
@@ -242,7 +380,7 @@ walk! {
     walk_while_statement_body: WhileStatementBody => {
         match node {
             WhileStatementBody::Statement { statement } => {
-                visitor.visit_statement(statement);
+                visitor.visit_statement(statement.as_mut());
             },
             WhileStatementBody::Block { statements, .. } => {
                 visitor.visit(statements)
@@ -272,7 +410,7 @@ walk! {
     walk_for_statement_body: ForStatementBody => {
         match node {
             ForStatementBody::Statement { statement } => {
-                visitor.visit_statement(statement);
+                visitor.visit_statement(statement.as_mut());
             },
             ForStatementBody::Block { statements, .. } => {
                 visitor.visit(statements)
@@ -1609,6 +1747,1425 @@ walk! {
             Type::Union(tys) |
             Type::Intersection(tys) => {
                 for ty in tys.iter_mut() {
+                    visitor.visit_type(ty);
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+walk! {
+    using(visitor, node);
+
+    walk_label: LabelStatement => {
+        visitor.visit_simple_identifier(&node.label)
+    }
+
+    walk_goto: GotoStatement => {
+        visitor.visit_simple_identifier(&node.label)
+    }
+
+    walk_static: StaticStatement => {
+        for variable in node.vars.iter() {
+            visitor.visit_static_var(variable)
+        }
+    }
+
+    walk_static_var: StaticVar => {
+        visitor.visit_variable(&node.var);
+
+        if let Some(default) = &node.default {
+            visitor.visit_expression(default);
+        }
+    }
+
+    walk_global: GlobalStatement => {
+        for variable in node.variables.iter() {
+            visitor.visit_variable(variable)
+        }
+    }
+
+    walk_do_while: DoWhileStatement => {
+        visitor.visit_statement(&node.body);
+        visitor.visit_expression(&node.condition);
+    }
+
+    walk_while: WhileStatement => {
+        visitor.visit_expression(&node.condition);
+        visitor.visit_while_statement_body(&node.body);
+    }
+
+    walk_while_statement_body: WhileStatementBody => {
+        match node {
+            WhileStatementBody::Statement { statement } => {
+                visitor.visit_statement(&statement);
+            },
+            WhileStatementBody::Block { statements, .. } => {
+                visitor.visit(&statements)
+            }
+        }
+    }
+
+    walk_for: ForStatement => {
+        visitor.visit_for_statement_iterator(&node.iterator);
+        visitor.visit_for_statement_body(&node.body);
+    }
+
+    walk_for_statement_iterator: ForStatementIterator => {
+        for init in node.initializations.iter() {
+            visitor.visit_expression(init);
+        }
+
+        for condition in node.conditions.iter() {
+            visitor.visit_expression(condition);
+        }
+
+        for r#loop in node.r#loop.iter() {
+            visitor.visit_expression(r#loop);
+        }
+    }
+
+    walk_for_statement_body: ForStatementBody => {
+        match node {
+            ForStatementBody::Statement { statement } => {
+                visitor.visit_statement(&statement);
+            },
+            ForStatementBody::Block { statements, .. } => {
+                visitor.visit(&statements)
+            }
+        }
+    }
+
+    walk_foreach: ForeachStatement => {
+        visitor.visit_foreach_statement_iterator(&node.iterator);
+        visitor.visit_foreach_statement_body(&node.body);
+    }
+
+    walk_foreach_statement_iterator: ForeachStatementIterator => {
+        match node {
+            ForeachStatementIterator::Value { expression, value, .. } => {
+                visitor.visit_expression(&expression);
+                visitor.visit_expression(&value);
+            },
+            ForeachStatementIterator::KeyAndValue { expression, key, value, .. } => {
+                visitor.visit_expression(&expression);
+                visitor.visit_expression(&key);
+                visitor.visit_expression(&value);
+            },
+        }
+    }
+
+    walk_foreach_statement_body: ForeachStatementBody => {
+        match node {
+            ForeachStatementBody::Statement { statement } => {
+                visitor.visit_statement(&statement)
+            },
+            ForeachStatementBody::Block { statements, .. } => {
+                visitor.visit(&statements)
+            }
+        }
+    }
+
+    walk_if: IfStatement => {
+        visitor.visit_expression(&node.condition);
+        visitor.visit_if_statement_body(&node.body);
+    }
+
+    walk_if_statement_body: IfStatementBody => {
+        match node {
+            IfStatementBody::Statement { statement, elseifs, r#else } => {
+                visitor.visit_statement(&statement);
+
+                for r#elseif in elseifs.iter() {
+                    visitor.visit_if_statement_elseif(r#elseif);
+                }
+
+                if let Some(r#else) = r#else {
+                    visitor.visit_if_statement_else(&r#else);
+                }
+            },
+            IfStatementBody::Block { statements, elseifs, r#else, .. } => {
+                visitor.visit(&statements);
+
+                for r#elseif in elseifs.iter() {
+                    visitor.visit_if_statement_elseif_block(r#elseif);
+                }
+
+                if let Some(r#else) = r#else {
+                    visitor.visit_if_statement_else_block(&r#else);
+                }
+            },
+        }
+    }
+
+    walk_if_statement_elseif: IfStatementElseIf => {
+        visitor.visit_expression(&node.condition);
+        visitor.visit_statement(&node.statement);
+    }
+
+    walk_if_statement_elseif_block: IfStatementElseIfBlock => {
+        visitor.visit_expression(&node.condition);
+        visitor.visit(&node.statements);
+    }
+
+    walk_if_statement_else: IfStatementElse => {
+        visitor.visit_statement(&node.statement);
+    }
+
+    walk_if_statement_else_block: IfStatementElseBlock => {
+        visitor.visit(&node.statements);
+    }
+
+    walk_switch: SwitchStatement => {
+        visitor.visit_expression(&node.condition);
+
+        for case in node.cases.iter() {
+            visitor.visit_switch_case(case);
+        }
+    }
+
+    walk_switch_case: Case => {
+        if let Some(condition) = &node.condition {
+            visitor.visit_expression(condition);
+        }
+
+        visitor.visit(&node.body);
+    }
+
+    walk_level: Level => {
+        match node {
+            Level::Literal(literal) => visitor.visit_literal(&literal),
+            Level::Parenthesized { level, .. } => visitor.visit_level(&level),
+        }
+    }
+
+    walk_break: BreakStatement => {
+        if let Some(level) = &node.level {
+            visitor.visit_level(level);
+        }
+    }
+
+    walk_continue: ContinueStatement => {
+        if let Some(level) = &node.level {
+            visitor.visit_level(level);
+        }
+    }
+
+    walk_constant: ConstantStatement => {
+        for entry in node.entries.iter() {
+            visitor.visit_constant_entry(entry);
+        }
+    }
+
+    walk_constant_entry: ConstantEntry => {
+        visitor.visit_simple_identifier(&node.name);
+        visitor.visit_expression(&node.value);
+    }
+
+    walk_function: FunctionStatement => {
+        // FIXME: Walk attributes here.
+        visitor.visit_simple_identifier(&node.name);
+        visitor.visit_function_parameter_list(&node.parameters);
+        visitor.visit_function_body(&node.body);
+    }
+
+    walk_function_parameter_list: FunctionParameterList => {
+        for parameter in node.parameters.iter() {
+            visitor.visit_function_parameter(parameter);
+        }
+    }
+
+    walk_function_parameter: FunctionParameter => {
+        visitor.visit_simple_variable(&node.name);
+        // FIXME: Walk attributes here.
+
+        if let Some(ty) = &node.data_type {
+            visitor.visit_data_type(ty);
+        }
+
+        if let Some(default) = &node.default {
+            visitor.visit_expression(default);
+        }
+    }
+
+    walk_function_body: FunctionBody => {
+        visitor.visit(&node.statements);
+    }
+
+    walk_class: ClassStatement => {
+        // FIXME: Walk attributes here.
+        // FIXME: Walk modifiers here.
+        visitor.visit_simple_identifier(&node.name);
+
+        if let Some(extends) = &node.extends {
+            visitor.visit_class_extends(extends);
+        }
+
+        if let Some(implements) = &node.implements {
+            visitor.visit_class_implements(implements);
+        }
+
+        visitor.visit_class_body(&node.body);
+    }
+
+    walk_class_extends: ClassExtends => {
+        visitor.visit_simple_identifier(&node.parent);
+    }
+
+    walk_class_implements: ClassImplements => {
+        for interface in node.interfaces.iter() {
+            visitor.visit_simple_identifier(interface);
+        }
+    }
+
+    walk_class_body: ClassBody => {
+        for member in node.members.iter() {
+            visitor.visit_classish_member(member);
+        }
+    }
+
+    walk_classish_member: ClassishMember => {
+        match node {
+            ClassishMember::Constant(constant) => {
+                visitor.visit_classish_constant(&constant);
+            },
+            ClassishMember::TraitUsage(usage) => {
+                visitor.visit_trait_usage(&usage);
+            },
+            ClassishMember::Property(property) => {
+                visitor.visit_property(&property);
+            },
+            ClassishMember::VariableProperty(property) => {
+                visitor.visit_variable_property(&property);
+            },
+            ClassishMember::AbstractMethod(method) => {
+                visitor.visit_abstract_method(&method);
+            },
+            ClassishMember::AbstractConstructor(method) => {
+                visitor.visit_abstract_constructor(&method);
+            },
+            ClassishMember::ConcreteMethod(method) => {
+                visitor.visit_concrete_method(&method);
+            },
+            ClassishMember::ConcreteConstructor(method) => {
+                visitor.visit_concrete_constructor(&method);
+            },
+        }
+    }
+
+    walk_classish_constant: ClassishConstant => {
+        // FIXME: Walk attributes here.
+        // FIXME: Walk modifiers here.
+
+        for entries in node.entries.iter() {
+            visitor.visit_constant_entry(entries);
+        }
+    }
+
+    walk_trait_usage: TraitUsage => {
+        for r#trait in node.traits.iter() {
+            visitor.visit_simple_identifier(r#trait);
+        }
+
+        for adaptation in node.adaptations.iter() {
+            visitor.visit_trait_usage_adaptation(adaptation);
+        }
+    }
+
+    walk_trait_usage_adaptation: TraitUsageAdaptation => {
+        match node {
+            TraitUsageAdaptation::Alias { r#trait, method, alias, visibility } => {
+                if let Some(r#trait) = r#trait {
+                    visitor.visit_simple_identifier(&r#trait);
+                }
+
+                visitor.visit_simple_identifier(&method);
+                visitor.visit_simple_identifier(&alias);
+
+                if let Some(_visibility) = visibility {
+                    // FIXME: Visit visibility here.
+                    // visitor.visit_visibility_modifier(visibility);
+                }
+            },
+            TraitUsageAdaptation::Visibility { r#trait, method, visibility: _visibility } => {
+                if let Some(r#trait) = r#trait {
+                    visitor.visit_simple_identifier(&r#trait);
+                }
+
+                visitor.visit_simple_identifier(&method);
+                // FIXME: Visit visibility here.
+            },
+            TraitUsageAdaptation::Precedence { r#trait, method, insteadof } => {
+                if let Some(r#trait) = r#trait {
+                    visitor.visit_simple_identifier(&r#trait);
+                }
+
+                visitor.visit_simple_identifier(&method);
+
+                for insteadof in insteadof.iter() {
+                    visitor.visit_simple_identifier(insteadof);
+                }
+            }
+        }
+    }
+
+    walk_property: Property => {
+        // FIXME: Walk attributes here.
+        // FIXME: Walk modifiers here.
+
+        if let Some(ty) = &node.r#type {
+            visitor.visit_data_type(ty);
+        }
+
+        for entry in node.entries.iter() {
+            visitor.visit_property_entry(entry);
+        }
+    }
+
+    walk_property_entry: PropertyEntry => {
+        match node {
+            PropertyEntry::Uninitialized { variable } => {
+                visitor.visit_simple_variable(&variable);
+            },
+            PropertyEntry::Initialized { variable, value, .. } => {
+                visitor.visit_simple_variable(&variable);
+                visitor.visit_expression(&value);
+            },
+        }
+    }
+
+    walk_variable_property: VariableProperty => {
+        // FIXME: Walk attributes here.
+        // FIXME: Walk type here.
+
+        for entry in node.entries.iter() {
+            visitor.visit_property_entry(entry);
+        }
+    }
+
+    walk_abstract_method: AbstractMethod => {
+        // FIXME: Walk attributes here.
+        // FIXME: Walk modifiers here.
+
+        visitor.visit_simple_identifier(&node.name);
+        visitor.visit_function_parameter_list(&node.parameters);
+
+        if let Some(ty) = &node.return_type {
+            visitor.visit_return_type(ty);
+        }
+    }
+
+    walk_abstract_constructor: AbstractConstructor => {
+        // FIXME: Walk attributes here.
+        // FIXME: Walk modifiers here.
+
+        visitor.visit_constructor_parameter_list(&node.parameters);
+    }
+
+    walk_constructor_parameter_list: ConstructorParameterList => {
+        for parameter in node.parameters.iter() {
+            visitor.visit_constructor_parameter(parameter);
+        }
+    }
+
+    walk_constructor_parameter: ConstructorParameter => {
+        // FIXME: Walk attributes here.
+        // FIXME: Visit modifiers here.
+        // FIXME: Visit type here.
+        visitor.visit_simple_variable(&node.name);
+
+        if let Some(default) = &node.default {
+            visitor.visit_expression(default);
+        }
+    }
+
+    walk_concrete_method: ConcreteMethod => {
+        // FIXME: Walk attributes here.
+        // FIXME: Walk modifiers here.
+
+        visitor.visit_simple_identifier(&node.name);
+        visitor.visit_function_parameter_list(&node.parameters);
+
+        if let Some(ty) = &node.return_type {
+            visitor.visit_return_type(ty);
+        }
+
+        visitor.visit_method_body(&node.body);
+    }
+
+    walk_method_body: MethodBody => {
+        visitor.visit(&node.statements);
+    }
+
+    walk_concrete_constructor: ConcreteConstructor => {
+        // FIXME: Walk attributes here.
+        // FIXME: Walk modifiers here.
+
+        visitor.visit_constructor_parameter_list(&node.parameters);
+        visitor.visit_method_body(&node.body);
+    }
+
+    walk_interface: InterfaceStatement => {
+        // FIXME: Walk attributes here.
+
+        visitor.visit_simple_identifier(&node.name);
+
+        if let Some(extends) = &node.extends {
+            visitor.visit_interface_extends(extends);
+        }
+
+        visitor.visit_interface_body(&node.body);
+    }
+
+    walk_interface_extends: InterfaceExtends => {
+        for parent in node.parents.iter() {
+            visitor.visit_simple_identifier(parent);
+        }
+    }
+
+    walk_interface_body: InterfaceBody => {
+        for member in node.members.iter() {
+            visitor.visit_classish_member(member);
+        }
+    }
+
+    walk_trait: TraitStatement => {
+        // FIXME: Walk attributes here.
+
+        visitor.visit_simple_identifier(&node.name);
+        visitor.visit_trait_body(&node.body);
+    }
+
+    walk_trait_body: TraitBody => {
+        for member in node.members.iter() {
+            visitor.visit_classish_member(member);
+        }
+    }
+
+    walk_echo: EchoStatement => {
+        for value in node.values.iter() {
+            visitor.visit_expression(value);
+        }
+    }
+
+    walk_expression_stmt: ExpressionStatement => {
+        visitor.visit_expression(&node.expression);
+    }
+
+    walk_return: ReturnStatement => {
+        if let Some(expression) = &node.value {
+            visitor.visit_expression(expression);
+        }
+    }
+
+    walk_namespace: NamespaceStatement => {
+        match node {
+            NamespaceStatement::Unbraced(node) => {
+                visitor.visit_unbraced_namespace(&node);
+            },
+            NamespaceStatement::Braced(node) => {
+                visitor.visit_braced_namespace(&node);
+            },
+        }
+    }
+
+    walk_unbraced_namespace: UnbracedNamespace => {
+        visitor.visit_simple_identifier(&node.name);
+        visitor.visit(&node.statements);
+    }
+
+    walk_braced_namespace: BracedNamespace => {
+        if let Some(name) = &node.name {
+            visitor.visit_simple_identifier(name);
+        }
+
+        visitor.visit(&node.body.statements);
+    }
+
+    walk_use: UseStatement => {
+        for r#use in node.uses.iter() {
+            visitor.visit_use_use(r#use);
+        }
+    }
+
+    walk_use_use: Use => {
+        visitor.visit_simple_identifier(&node.name);
+
+        if let Some(alias) = &node.alias {
+            visitor.visit_simple_identifier(alias);
+        }
+    }
+
+    walk_group_use: GroupUseStatement => {
+        visitor.visit_simple_identifier(&node.prefix);
+
+        for r#use in node.uses.iter() {
+            visitor.visit_use_use(r#use);
+        }
+    }
+
+    walk_try: TryStatement => {
+        visitor.visit(&node.body);
+
+        for catch in node.catches.iter() {
+            visitor.visit_catch_block(catch);
+        }
+
+        if let Some(finally) = &node.finally {
+            visitor.visit_finally_block(finally);
+        }
+    }
+
+    walk_catch_block: CatchBlock => {
+        if let Some(variable) = &node.var {
+            visitor.visit_simple_variable(variable);
+        }
+
+        visitor.visit(&node.body);
+    }
+
+    walk_finally_block: FinallyBlock => {
+        visitor.visit(&node.body);
+    }
+
+    walk_unit_enum: UnitEnumStatement => {
+        // FIXME: Walk attributes here.
+
+        visitor.visit_simple_identifier(&node.name);
+
+        for implements in node.implements.iter() {
+            visitor.visit_simple_identifier(implements);
+        }
+
+        for member in node.body.members.iter() {
+            visitor.visit_unit_enum_member(member);
+        }
+    }
+
+    walk_unit_enum_member: UnitEnumMember => {
+        match node {
+            UnitEnumMember::Case(node) => {
+                visitor.visit_unit_enum_case(&node);
+            }
+            UnitEnumMember::Classish(node) => {
+                visitor.visit_classish_member(&node);
+            }
+        }
+    }
+
+    walk_unit_enum_case: UnitEnumCase => {
+        // FIXME: Walk attributes here.
+
+        visitor.visit_simple_identifier(&node.name);
+    }
+
+    walk_backed_enum: BackedEnumStatement => {
+        // FIXME: Walk attributes here.
+
+        visitor.visit_simple_identifier(&node.name);
+
+        for implements in node.implements.iter() {
+            visitor.visit_simple_identifier(implements);
+        }
+
+        for member in node.body.members.iter() {
+            visitor.visit_backed_enum_member(member);
+        }
+    }
+
+    walk_backed_enum_member: BackedEnumMember => {
+        match node {
+            BackedEnumMember::Case(node) => {
+                visitor.visit_backed_enum_case(&node);
+            }
+            BackedEnumMember::Classish(node) => {
+                visitor.visit_classish_member(&node);
+            }
+        }
+    }
+
+    walk_backed_enum_case: BackedEnumCase => {
+        // FIXME: Walk attributes here.
+
+        visitor.visit_simple_identifier(&node.name);
+        visitor.visit_expression(&node.value);
+    }
+
+    walk_declare: DeclareStatement => {
+        for entry in node.entries.entries.iter() {
+            visitor.visit_declare_entry(entry);
+        }
+
+        visitor.visit_declare_body(&node.body);
+    }
+
+    walk_declare_entry: DeclareEntry => {
+        visitor.visit_simple_identifier(&node.key);
+        visitor.visit_literal(&node.value);
+    }
+
+    walk_declare_body: DeclareBody => {
+        match node {
+            DeclareBody::Noop { .. } => {},
+            DeclareBody::Braced { statements, .. } => {
+                visitor.visit(&statements);
+            },
+            DeclareBody::Expression { expression, .. } => {
+                visitor.visit_expression(&expression);
+            },
+            DeclareBody::Block { statements, .. } => {
+                visitor.visit(&statements);
+            },
+        }
+    }
+
+    walk_argument_list: ArgumentList => {
+        for argument in node.arguments.iter() {
+            visitor.visit_argument(argument);
+        }
+    }
+
+    walk_argument: Argument => {
+        match node {
+            Argument::Positional(node) => {
+                visitor.visit_expression(&node.value);
+            },
+            Argument::Named(node) => {
+                visitor.visit_simple_identifier(&node.name);
+                visitor.visit_expression(&node.value);
+            },
+        }
+    }
+
+    walk_eval: EvalExpression => {
+        if let Some(argument) = &node.argument.argument {
+            visitor.visit_argument(argument);
+        }
+    }
+
+    walk_empty: EmptyExpression => {
+        if let Some(argument) = &node.argument.argument {
+            visitor.visit_argument(argument);
+        }
+    }
+
+    walk_die: DieExpression => {
+        if let Some(argument) = &node.argument {
+            if let Some(argument) = &argument.argument {
+                visitor.visit_argument(argument);
+            }
+        }
+    }
+
+    walk_exit: ExitExpression => {
+        if let Some(argument) = &node.argument {
+            if let Some(argument) = &argument.argument {
+                visitor.visit_argument(argument);
+            }
+        }
+    }
+
+    walk_isset: IssetExpression => {
+        visitor.visit_argument_list(&node.arguments);
+    }
+
+    walk_unset: UnsetExpression => {
+        visitor.visit_argument_list(&node.arguments);
+    }
+
+    walk_print: PrintExpression => {
+        if let Some(value) = &node.value {
+            visitor.visit_expression(value);
+        }
+
+        if let Some(argument) = &node.argument {
+            if let Some(argument) = &argument.argument {
+                visitor.visit_argument(argument);
+            }
+        }
+    }
+
+    walk_arithmetic_operation: ArithmeticOperationExpression => {
+        match node {
+            ArithmeticOperationExpression::Addition {
+                left,
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&left);
+                visitor.visit_expression(&right);
+            },
+            ArithmeticOperationExpression::Subtraction {
+                left,
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&left);
+                visitor.visit_expression(&right);
+            },
+            ArithmeticOperationExpression::Multiplication {
+                left,
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&left);
+                visitor.visit_expression(&right);
+            },
+            ArithmeticOperationExpression::Division {
+                left,
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&left);
+                visitor.visit_expression(&right);
+            },
+            ArithmeticOperationExpression::Modulo {
+                left, right, ..
+            }  => {
+                visitor.visit_expression(&left);
+                visitor.visit_expression(&right);
+            },
+            ArithmeticOperationExpression::Exponentiation {
+                left, right, ..
+            } => {
+                visitor.visit_expression(&left);
+                visitor.visit_expression(&right);
+            },
+            ArithmeticOperationExpression::Negative {
+                right, ..
+            } => {
+                visitor.visit_expression(&right);
+            },
+            ArithmeticOperationExpression::Positive {
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&right);
+            },
+            ArithmeticOperationExpression::PreIncrement {
+                right, ..
+            } => {
+                visitor.visit_expression(&right);
+            },
+            ArithmeticOperationExpression::PostIncrement {
+                left, ..
+            } => {
+                visitor.visit_expression(&left);
+            },
+            ArithmeticOperationExpression::PreDecrement {
+                right, ..
+            } => {
+                visitor.visit_expression(&right);
+            },
+            ArithmeticOperationExpression::PostDecrement {
+                left, ..
+            } => {
+                visitor.visit_expression(&left);
+            },
+        }
+    }
+
+    walk_assignment_operation: AssignmentOperationExpression => {
+        match node {
+            AssignmentOperationExpression::Assign {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::Addition {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::Subtraction {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::Multiplication {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::Division {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::Modulo {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::Exponentiation {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::Concat {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::BitwiseAnd {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::BitwiseOr {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::BitwiseXor {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::LeftShift {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::RightShift {
+                left,
+                right,
+                ..
+            } |
+            AssignmentOperationExpression::Coalesce {
+                left,
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&left);
+                visitor.visit_expression(&right);
+            }
+        }
+    }
+
+    walk_bitwise_operation: BitwiseOperationExpression => {
+        match node {
+            BitwiseOperationExpression::And {
+                left,
+                right,
+                ..
+            } |
+            BitwiseOperationExpression::Or {
+                left,
+                right,
+                ..
+            } |
+            BitwiseOperationExpression::Xor {
+                left,
+                right,
+                ..
+            } |
+            BitwiseOperationExpression::LeftShift {
+                left,
+                right,
+                ..
+            } |
+            BitwiseOperationExpression::RightShift {
+                left,
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&left);
+                visitor.visit_expression(&right);
+            },
+            BitwiseOperationExpression::Not {
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&right);
+            },
+        }
+    }
+
+    walk_comparison_operation: ComparisonOperationExpression => {
+        match node {
+            ComparisonOperationExpression::Equal {
+                left,
+                right,
+                ..
+            } |
+            ComparisonOperationExpression::Identical {
+                left,
+                right,
+                ..
+            } |
+            ComparisonOperationExpression::NotEqual {
+                left,
+                right,
+                ..
+            } |
+            ComparisonOperationExpression::AngledNotEqual {
+                left,
+                right,
+                ..
+            } |
+            ComparisonOperationExpression::NotIdentical {
+                left,
+                right,
+                ..
+            } |
+            ComparisonOperationExpression::LessThan {
+                left,
+                right,
+                ..
+            } |
+            ComparisonOperationExpression::GreaterThan {
+                left,
+                right,
+                ..
+            } |
+            ComparisonOperationExpression::LessThanOrEqual {
+                left,
+                right,
+                ..
+            } |
+            ComparisonOperationExpression::GreaterThanOrEqual {
+                left,
+                right,
+                ..
+            } |
+            ComparisonOperationExpression::Spaceship {
+                left,
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&left);
+                visitor.visit_expression(&right);
+            }
+        }
+    }
+
+    walk_logical_operation: LogicalOperationExpression => {
+        match node {
+            LogicalOperationExpression::And {
+                left,
+                right,
+                ..
+            } |
+            LogicalOperationExpression::Or {
+                left,
+                right,
+                ..
+            } |
+            LogicalOperationExpression::LogicalAnd {
+                left,
+                right,
+                ..
+            } |
+            LogicalOperationExpression::LogicalOr {
+                left,
+                right,
+                ..
+            } |
+            LogicalOperationExpression::LogicalXor {
+                left,
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&left);
+                visitor.visit_expression(&right);
+            },
+            LogicalOperationExpression::Not {
+                right,
+                ..
+            } => {
+                visitor.visit_expression(&right);
+            },
+        }
+    }
+
+    walk_concat: ConcatExpression => {
+        visitor.visit_expression(&node.left);
+        visitor.visit_expression(&node.right);
+    }
+
+    walk_instanceof: InstanceofExpression => {
+        visitor.visit_expression(&node.left);
+        visitor.visit_expression(&node.right);
+    }
+
+    walk_reference: ReferenceExpression => {
+        visitor.visit_expression(&node.right);
+    }
+
+    walk_parenthesized: ParenthesizedExpression => {
+        visitor.visit_expression(&node.expr);
+    }
+
+    walk_error_suppress: ErrorSuppressExpression => {
+        visitor.visit_expression(&node.expr);
+    }
+
+    walk_identifier: Identifier => {
+        match node {
+            Identifier::SimpleIdentifier(node) => {
+                visitor.visit_simple_identifier(&node);
+            },
+            Identifier::DynamicIdentifier(node) => {
+                visitor.visit_dynamic_identifier(&node);
+            },
+        }
+    }
+
+    walk_dynamic_identifier: DynamicIdentifier => {
+        visitor.visit_expression(&node.expr);
+    }
+
+    walk_variable: Variable => {
+        match node {
+            Variable::SimpleVariable(node) => {
+                visitor.visit_simple_variable(&node);
+            },
+            Variable::VariableVariable(node) => {
+                visitor.visit_variable_variable(&node);
+            },
+            Variable::BracedVariableVariable(node) => {
+                visitor.visit_braced_variable_variable(&node);
+            }
+        }
+    }
+
+    walk_variable_variable: VariableVariable => {
+        visitor.visit_variable(&node.variable);
+    }
+
+    walk_braced_variable_variable: BracedVariableVariable => {
+        visitor.visit_expression(&node.variable);
+    }
+
+    walk_include: IncludeExpression => {
+        visitor.visit_expression(&node.path);
+    }
+
+    walk_include_once: IncludeOnceExpression => {
+        visitor.visit_expression(&node.path);
+    }
+
+    walk_require: RequireExpression => {
+        visitor.visit_expression(&node.path);
+    }
+
+    walk_require_once: RequireOnceExpression => {
+        visitor.visit_expression(&node.path);
+    }
+
+    walk_function_call: FunctionCallExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_argument_list(&node.arguments);
+    }
+
+    walk_function_closure_creation: FunctionClosureCreationExpression => {
+        visitor.visit_expression(&node.target);
+    }
+
+    walk_method_call: MethodCallExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_expression(&node.method);
+        visitor.visit_argument_list(&node.arguments);
+    }
+
+    walk_method_closure_creation: MethodClosureCreationExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_expression(&node.method);
+    }
+
+    walk_nullsafe_method_call: NullsafeMethodCallExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_expression(&node.method);
+        visitor.visit_argument_list(&node.arguments);
+    }
+
+    walk_static_method_call: StaticMethodCallExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_identifier(&node.method);
+        visitor.visit_argument_list(&node.arguments);
+    }
+
+    walk_static_variable_method_call: StaticVariableMethodCallExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_variable(&node.method);
+        visitor.visit_argument_list(&node.arguments);
+    }
+
+    walk_static_method_closure_creation: StaticMethodClosureCreationExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_identifier(&node.method);
+    }
+
+    walk_static_variable_method_closure_creation: StaticVariableMethodClosureCreationExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_variable(&node.method);
+    }
+
+    walk_property_fetch: PropertyFetchExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_expression(&node.property);
+    }
+
+    walk_nullsafe_property_fetch: NullsafePropertyFetchExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_expression(&node.property);
+    }
+
+    walk_static_property_fetch: StaticPropertyFetchExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_variable(&node.property);
+    }
+
+    walk_constant_fetch: ConstantFetchExpression => {
+        visitor.visit_expression(&node.target);
+        visitor.visit_identifier(&node.constant);
+    }
+
+    walk_array_item: ArrayItem => {
+        match node {
+            ArrayItem::Skipped => {},
+            ArrayItem::Value {
+                value
+            } => {
+                visitor.visit_expression(&value);
+            },
+            ArrayItem::ReferencedValue {
+                value, ..
+            } => {
+                visitor.visit_expression(&value);
+            },
+            ArrayItem::SpreadValue {
+                value, ..
+            } => {
+                visitor.visit_expression(&value);
+            },
+            ArrayItem::KeyValue {
+                key,
+                value,
+                ..
+            } => {
+                visitor.visit_expression(&key);
+                visitor.visit_expression(&value);
+            },
+            ArrayItem::ReferencedKeyValue {
+                key,
+                value, ..
+            } => {
+                visitor.visit_expression(&key);
+                visitor.visit_expression(&value);
+            },
+        }
+    }
+
+    walk_short_array: ShortArrayExpression => {
+        for item in node.items.inner.iter() {
+            visitor.visit_array_item(item);
+        }
+    }
+
+    walk_array: ArrayExpression => {
+        for item in node.items.inner.iter() {
+            visitor.visit_array_item(item);
+        }
+    }
+
+    walk_list: ListExpression => {
+        for entry in node.items.iter() {
+            visitor.visit_list_entry(entry);
+        }
+    }
+
+    walk_list_entry: ListEntry => {
+        match node {
+            ListEntry::Skipped => {},
+            ListEntry::Value {
+                value
+            } => {
+                visitor.visit_expression(&value);
+            },
+            ListEntry::KeyValue {
+                key,
+                value,
+                ..
+            } => {
+                visitor.visit_expression(&key);
+                visitor.visit_expression(&value);
+            },
+        }
+    }
+
+    walk_closure: ClosureExpression => {
+        // FIXME: Walk attributes here.
+
+        visitor.visit_function_parameter_list(&node.parameters);
+
+        if let Some(return_type) = &node.return_type {
+            visitor.visit_return_type(return_type);
+        }
+
+        visitor.visit_function_body(&node.body);
+    }
+
+    walk_arrow_function: ArrowFunctionExpression => {
+        // FIXME: Walk attributes here.
+
+        visitor.visit_function_parameter_list(&node.parameters);
+        visitor.visit_expression(&node.body);
+    }
+
+    walk_new: NewExpression => {
+        visitor.visit_expression(&node.target);
+
+        if let Some(arguments) = &node.arguments {
+            visitor.visit_argument_list(arguments);
+        }
+    }
+
+    walk_interpolated_string: InterpolatedStringExpression => {
+        for part in node.parts.iter() {
+            visitor.visit_string_part(part);
+        }
+    }
+
+    walk_string_part: StringPart => {
+        match node {
+            StringPart::Literal(node) => {
+                visitor.visit_literal_string_part(&node);
+            },
+            StringPart::Expression(node) => {
+                visitor.visit_expression_string_part(&node);
+            }
+        }
+    }
+
+    walk_expression_string_part: ExpressionStringPart => {
+        visitor.visit_expression(&node.expression);
+    }
+
+    walk_heredoc: HeredocExpression => {
+        for part in node.parts.iter() {
+            visitor.visit_string_part(part);
+        }
+    }
+
+    walk_shell_exec: ShellExecExpression => {
+        for part in node.parts.iter() {
+            visitor.visit_string_part(part);
+        }
+    }
+
+    walk_anonymous_class: AnonymousClassExpression => {
+        // FIXME: Walk attributes here.
+
+        if let Some(extends) = &node.extends {
+            visitor.visit_class_extends(extends);
+        }
+
+        if let Some(implements) = &node.implements {
+            visitor.visit_class_implements(implements);
+        }
+
+        visitor.visit_anonymous_class_body(&node.body);
+    }
+
+    walk_anonymous_class_body: AnonymousClassBody => {
+        for member in node.members.iter() {
+            visitor.visit_classish_member(member);
+        }
+    }
+
+    walk_array_index: ArrayIndexExpression => {
+        visitor.visit_expression(&node.array);
+
+        if let Some(index) = &node.index {
+            visitor.visit_expression(index);
+        }
+    }
+
+    walk_short_ternary: ShortTernaryExpression => {
+        visitor.visit_expression(&node.condition);
+        visitor.visit_expression(&node.r#else);
+    }
+
+    walk_ternary: TernaryExpression => {
+        visitor.visit_expression(&node.condition);
+        visitor.visit_expression(&node.then);
+        visitor.visit_expression(&node.r#else);
+    }
+
+    walk_coalesce: CoalesceExpression => {
+        visitor.visit_expression(&node.lhs);
+        visitor.visit_expression(&node.rhs);
+    }
+
+    walk_clone: CloneExpression => {
+        visitor.visit_expression(&node.target);
+    }
+
+    walk_match: MatchExpression => {
+        visitor.visit_expression(&node.condition);
+
+        for arm in node.arms.iter() {
+            visitor.visit_match_arm(arm);
+        }
+
+        if let Some(default) = &node.default {
+            visitor.visit_default_match_arm(default);
+        }
+    }
+
+    walk_match_arm: MatchArm => {
+        for condition in node.conditions.iter() {
+            visitor.visit_expression(condition);
+        }
+
+        visitor.visit_expression(&node.body);
+    }
+
+    walk_default_match_arm: DefaultMatchArm => {
+        visitor.visit_expression(&node.body);
+    }
+
+    walk_throw: ThrowExpression => {
+        visitor.visit_expression(&node.value);
+    }
+
+    walk_yield: YieldExpression => {
+        if let Some(key) = &node.key {
+            visitor.visit_expression(key);
+        }
+
+        if let Some(value) = &node.value {
+            visitor.visit_expression(value);
+        }
+    }
+
+    walk_yield_from: YieldFromExpression => {
+        visitor.visit_expression(&node.value);
+    }
+
+    walk_cast: CastExpression => {
+        visitor.visit_expression(&node.value);
+    }
+
+    walk_return_type: ReturnType => {
+        visitor.visit_data_type(&node.data_type);
+    }
+
+    walk_data_type: DataType => {
+        visitor.visit_type(&node.kind);
+    }
+
+    walk_type: Type => {
+        match node {
+            Type::Nullable(ty) => {
+                visitor.visit_type(&ty);
+            },
+            Type::Union(tys) |
+            Type::Intersection(tys) => {
+                for ty in tys.iter() {
                     visitor.visit_type(ty);
                 }
             },

--- a/crates/pxp-visitor/src/walk.rs
+++ b/crates/pxp-visitor/src/walk.rs
@@ -1,3 +1,4 @@
+use paste::paste;
 use pxp_ast::{
     arguments::{Argument, ArgumentList},
     classes::{
@@ -57,13 +58,13 @@ use pxp_type::Type;
 
 use crate::VisitorMut;
 
-pub fn walk<V: VisitorMut + ?Sized>(visitor: &mut V, program: &mut [Statement]) {
+pub fn walk_mut<V: VisitorMut + ?Sized>(visitor: &mut V, program: &mut [Statement]) {
     for statement in program.iter_mut() {
         visitor.visit_statement(statement);
     }
 }
 
-pub fn walk_statement<V: VisitorMut + ?Sized>(visitor: &mut V, statement: &mut Statement) {
+pub fn walk_statement_mut<V: VisitorMut + ?Sized>(visitor: &mut V, statement: &mut Statement) {
     match &mut statement.kind {
         StatementKind::FullOpeningTag(stmt) => visitor.visit_full_opening_tag(stmt),
         StatementKind::ShortOpeningTag(stmt) => visitor.visit_short_opening_tag(stmt),
@@ -104,7 +105,7 @@ pub fn walk_statement<V: VisitorMut + ?Sized>(visitor: &mut V, statement: &mut S
     };
 }
 
-pub fn walk_expression<V: VisitorMut + ?Sized>(visitor: &mut V, expression: &mut Expression) {
+pub fn walk_expression_mut<V: VisitorMut + ?Sized>(visitor: &mut V, expression: &mut Expression) {
     match &mut expression.kind {
         ExpressionKind::Missing => visitor.visit_missing_expr(),
         ExpressionKind::Eval(expr) => visitor.visit_eval(expr),
@@ -190,7 +191,9 @@ macro_rules! walk {
         $($label:ident: $node:ty => $body:block )+
     ) => {
         $(
-            pub fn $label<V: VisitorMut + ?Sized>($v: &mut V, $n: &mut $node) $body
+            paste! {
+                pub fn [<$label _mut>]<V: VisitorMut + ?Sized>($v: &mut V, $n: &mut $node) $body
+            }
         )+
     }
 }


### PR DESCRIPTION
The old code had a single trait `Visitor` that enforced passing a mutable reference to an AST.

This new version has two separate traits – `Visitor` and `VisitorMut`. 

It's an early optimisation but worth doing now since the impact is low. It means we don't need to pass around `&mut [Statement]` everywhere, especially when we don't need it (indexing for example).