### PR TITLE
NameResolver: Introduce new crate for resolving names

### DIFF
--- a/crates/pxp-ast/src/lib.rs
+++ b/crates/pxp-ast/src/lib.rs
@@ -65,7 +65,7 @@ pub mod data_type;
 pub type Block = Vec<Statement>;
 pub type NodeId = usize;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Copy)]
 
 pub enum UseKind {
     Normal,
@@ -139,7 +139,6 @@ pub struct EchoStatement {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-
 pub struct ReturnStatement {
     pub r#return: Span,
     pub value: Option<Expression>,
@@ -147,14 +146,12 @@ pub struct ReturnStatement {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-
 pub struct UseStatement {
     pub kind: UseKind,
     pub uses: Vec<Use>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-
 pub struct GroupUseStatement {
     pub prefix: SimpleIdentifier,
     pub kind: UseKind,

--- a/crates/pxp-name-resolver/Cargo.toml
+++ b/crates/pxp-name-resolver/Cargo.toml
@@ -9,4 +9,5 @@ rust-version.workspace = true
 
 [dependencies]
 pxp-ast = { version = "0.1.0", path = "../pxp-ast" }
+pxp-symbol = { version = "0.1.0", path = "../pxp-symbol" }
 pxp-visitor = { version = "0.1.0", path = "../pxp-visitor" }

--- a/crates/pxp-name-resolver/Cargo.toml
+++ b/crates/pxp-name-resolver/Cargo.toml
@@ -8,3 +8,5 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+pxp-ast = { version = "0.1.0", path = "../pxp-ast" }
+pxp-visitor = { version = "0.1.0", path = "../pxp-visitor" }

--- a/crates/pxp-name-resolver/Cargo.toml
+++ b/crates/pxp-name-resolver/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "pxp-name-resolver"
+version = "0.1.0"
+edition = "2021"
+license-file.workspace = true
+rust-version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/pxp-name-resolver/README.md
+++ b/crates/pxp-name-resolver/README.md
@@ -1,0 +1,3 @@
+# Name Resolver
+
+This crate provides a single `NameResolvingVisitor` that takes in a `&mut [Statement]` and mutates `SimpleIdentifier` nodes **in place**, replacing the given name with a fully-resolved name where applicable.

--- a/crates/pxp-name-resolver/src/lib.rs
+++ b/crates/pxp-name-resolver/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/crates/pxp-name-resolver/src/lib.rs
+++ b/crates/pxp-name-resolver/src/lib.rs
@@ -1,14 +1,23 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+use pxp_visitor::VisitorMut;
+
+#[derive(Debug)]
+pub struct NameResolvingVisitor {
+    context: NameResolvingContext,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl NameResolvingVisitor {
+    pub fn new() -> Self {
+        NameResolvingVisitor {
+            context: NameResolvingContext {},
+        }
     }
+}
+
+#[derive(Debug)]
+struct NameResolvingContext {
+
+}
+
+impl VisitorMut for NameResolvingVisitor {
+
 }

--- a/crates/pxp-name-resolver/src/lib.rs
+++ b/crates/pxp-name-resolver/src/lib.rs
@@ -1,23 +1,88 @@
-use pxp_visitor::VisitorMut;
+use std::{collections::HashMap, task::Context};
+
+use pxp_ast::{identifiers::SimpleIdentifier, namespaces::{BracedNamespace, NamespaceStatement, UnbracedNamespace}, Statement, UseKind, UseStatement};
+use pxp_symbol::{Symbol, SymbolTable};
+use pxp_visitor::{walk_mut, walk_namespace_mut, walk_use_mut, VisitorMut};
 
 #[derive(Debug)]
-pub struct NameResolvingVisitor {
+pub struct NameResolvingVisitor<'a> {
     context: NameResolvingContext,
+    symbols: &'a mut SymbolTable,
 }
 
-impl NameResolvingVisitor {
-    pub fn new() -> Self {
+impl<'a> NameResolvingVisitor<'a> {
+    pub fn new(symbols: &'a mut SymbolTable) -> Self {
         NameResolvingVisitor {
-            context: NameResolvingContext {},
+            context: NameResolvingContext::default(),
+            symbols,
         }
+    }
+
+    pub fn get_context(&self) -> &NameResolvingContext {
+        &self.context
     }
 }
 
-#[derive(Debug)]
-struct NameResolvingContext {
+impl VisitorMut for NameResolvingVisitor<'_> {
+    fn visit(&mut self, node: &mut [Statement]) {
+        self.context = NameResolvingContext::new();
+        walk_mut(self, node);
+    }
 
+    fn visit_namespace(&mut self, node: &mut NamespaceStatement) {
+        match node {
+            NamespaceStatement::Unbraced(UnbracedNamespace { name, .. }) =>{
+                self.context.start_namespace(Some(name.clone()));
+            },
+            NamespaceStatement::Braced(BracedNamespace { name, .. }) => {
+                self.context.start_namespace(name.clone());
+            },
+        };
+
+        walk_namespace_mut(self, node);
+    }
+
+    fn visit_use(&mut self, node: &mut UseStatement) {
+        for r#use in node.uses.iter() {
+            if r#use.name.symbol.is_missing() {
+                continue;
+            }
+
+            let kind = r#use.kind.unwrap_or(node.kind);
+            let alias = r#use.alias.as_ref().map_or(r#use.name.get_last_part(), |alias| alias.symbol);
+            let name = r#use.name.symbol;
+
+            self.context.add_alias(kind, alias, name);
+        }
+
+        walk_use_mut(self, node);
+    }
 }
 
-impl VisitorMut for NameResolvingVisitor {
+#[derive(Debug, Default)]
+pub struct NameResolvingContext {
+    namespace: Option<SimpleIdentifier>,
+    aliases: HashMap<UseKind, HashMap<Symbol, Symbol>>,
+}
 
+impl NameResolvingContext {
+    fn new() -> Self {
+        let mut aliases = HashMap::new();
+        aliases.insert(UseKind::Normal, HashMap::new());
+        aliases.insert(UseKind::Function, HashMap::new());
+        aliases.insert(UseKind::Const, HashMap::new());
+
+        Self {
+            namespace: None,
+            aliases,
+        }
+    }
+
+    fn start_namespace(&mut self, namespace: Option<SimpleIdentifier>) {
+        self.namespace = namespace;
+    }
+
+    fn add_alias(&mut self, kind: UseKind, alias: Symbol, name: Symbol) {
+        self.aliases.get_mut(&kind).unwrap().insert(alias, name);
+    }
 }

--- a/crates/pxp-symbol/src/lib.rs
+++ b/crates/pxp-symbol/src/lib.rs
@@ -6,6 +6,12 @@ use serde::{Serialize, Deserialize};
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub struct Symbol(pub usize);
 
+impl Symbol {
+    pub fn is_missing(&self) -> bool {
+        self.0 == 0
+    }
+}
+
 impl Debug for Symbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(contents) = SymbolTable::the().resolve(*self) {

--- a/crates/pxp-tools/Cargo.toml
+++ b/crates/pxp-tools/Cargo.toml
@@ -13,6 +13,8 @@ pxp-token = { path = "../pxp-token" }
 pxp-parser = { path = "../pxp-parser" }
 discoverer = "0.2.0"
 rustyline = "13.0.0"
+pxp-name-resolver = { version = "0.1.0", path = "../pxp-name-resolver" }
+pxp-visitor = { version = "0.1.0", path = "../pxp-visitor" }
 
 [[bin]]
 name = "tokenise"
@@ -21,3 +23,7 @@ path = "bin/tokenise.rs"
 [[bin]]
 name = "parse"
 path = "bin/parse.rs"
+
+[[bin]]
+name = "name-resolver"
+path = "bin/name_resolver.rs"

--- a/crates/pxp-tools/bin/name_resolver.rs
+++ b/crates/pxp-tools/bin/name_resolver.rs
@@ -1,0 +1,24 @@
+use std::{env::args, fs::read};
+
+use pxp_name_resolver::NameResolvingVisitor;
+use pxp_parser::parse;
+use pxp_symbol::SymbolTable;
+use pxp_visitor::VisitorMut;
+
+fn main() {
+    let args = args().skip(1).collect::<Vec<_>>();
+    let file = args.get(0).expect("File not provided.");
+    let contents = read(file).expect("Failed to read file.");
+    let mut result = parse(&contents, SymbolTable::the());
+    let mut name_resolver = NameResolvingVisitor::new(SymbolTable::the());
+    
+    name_resolver.visit(&mut result.ast);
+
+    if args.contains(&"--context".to_string()) {
+        dbg!(name_resolver.get_context());
+    }
+    
+    if args.contains(&"--ast".to_string()) {
+        dbg!(result.ast);
+    }
+}


### PR DESCRIPTION
Inspired by the `NameResolver` visitor in `nikic/PHP-Parser`, this new crate provides a simple `Visitor` that iterates through an AST and converts simple `Identifier` values into fully-resolved names (where possible & applicable).

This will greatly reduce code duplication during type analysis and indexing and means we can keep all of this name resolution logic in a single place.

Closes #41.