### PR TITLE
Language Server Implementation

### DIFF
--- a/crates/pxp-diagnostics/src/lib.rs
+++ b/crates/pxp-diagnostics/src/lib.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use pxp_span::Span;
 pub use severity::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Diagnostic<K: Display> {
     pub kind: K,
     pub severity: Severity,

--- a/crates/pxp-diagnostics/src/severity.rs
+++ b/crates/pxp-diagnostics/src/severity.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Severity {
     Hint,
     Information,

--- a/crates/pxp-ls/Cargo.toml
+++ b/crates/pxp-ls/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pxp-ls"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = { version = "1.17.0", features = ["full"] }
+tower-lsp = { version = "0.20.0", features = ["proposed"]}
+dashmap = "5.1.0"
+pxp-parser = { path = "../pxp-parser" }
+pxp-symbol= { path = "../pxp-symbol" }
+pxp-diagnostics = { path = "../pxp-diagnostics" }
+

--- a/crates/pxp-ls/src/capabilities.rs
+++ b/crates/pxp-ls/src/capabilities.rs
@@ -1,0 +1,108 @@
+use tower_lsp::lsp_types::{
+    CompletionOptions, 
+    DeclarationCapability, 
+    DiagnosticOptions, 
+    DocumentSymbolOptions,
+    FileOperationRegistrationOptions, 
+    HoverProviderCapability, 
+    ImplementationProviderCapability,
+    InitializeParams, 
+    OneOf, 
+    ReferencesOptions, 
+    RenameOptions, 
+    SelectionRangeProviderCapability,
+    ServerCapabilities, 
+    SignatureHelpOptions, 
+    TextDocumentSyncCapability, 
+    TextDocumentSyncKind,
+    TypeDefinitionProviderCapability, 
+    WorkDoneProgressOptions,
+    WorkspaceFileOperationsServerCapabilities, 
+    WorkspaceFoldersServerCapabilities,
+    WorkspaceServerCapabilities,
+    DiagnosticServerCapabilities,
+};
+
+pub(crate) fn get_server_capabilities(_params: InitializeParams) -> ServerCapabilities {
+    ServerCapabilities {
+        position_encoding: None,
+        text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+        selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
+        completion_provider: Some(CompletionOptions {
+            resolve_provider: Some(true),
+            trigger_characters: None,
+            work_done_progress_options: Default::default(),
+            all_commit_characters: None,
+            completion_item: None,
+        }),
+        signature_help_provider: Some(SignatureHelpOptions {
+            trigger_characters: None,
+            retrigger_characters: None,
+            work_done_progress_options: WorkDoneProgressOptions {
+                work_done_progress: None,
+            },
+        }),
+        definition_provider: Some(OneOf::Left(true)),
+        type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
+        implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
+        references_provider: Some(OneOf::Right(ReferencesOptions {
+            work_done_progress_options: WorkDoneProgressOptions {
+                work_done_progress: None,
+            },
+        })),
+        document_highlight_provider: None,
+        document_symbol_provider: Some(OneOf::Right(DocumentSymbolOptions {
+            label: Some("Document Symbol".to_string()),
+            work_done_progress_options: WorkDoneProgressOptions {
+                work_done_progress: None,
+            },
+        })),
+        workspace_symbol_provider: Some(OneOf::Left(true)),
+        code_action_provider: None,
+        code_lens_provider: None,
+        document_formatting_provider: None,
+        document_range_formatting_provider: None,
+        document_on_type_formatting_provider: None,
+        rename_provider: Some(OneOf::Right(RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: WorkDoneProgressOptions {
+                work_done_progress: None,
+            },
+        })),
+        document_link_provider: None,
+        color_provider: None,
+        folding_range_provider: None,
+        declaration_provider: Some(DeclarationCapability::Simple(true)),
+        execute_command_provider: None,
+        workspace: Some(WorkspaceServerCapabilities {
+            workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                supported: Some(true),
+                change_notifications: Some(OneOf::Left(true)),
+            }),
+            file_operations: Some(WorkspaceFileOperationsServerCapabilities {
+                did_create: Some(FileOperationRegistrationOptions { filters: vec![] }),
+                did_rename: Some(FileOperationRegistrationOptions { filters: vec![] }),
+                did_delete: Some(FileOperationRegistrationOptions { filters: vec![] }),
+                will_rename: None,
+                will_create: None,
+                will_delete: None,
+            }),
+        }),
+        call_hierarchy_provider: None,
+        semantic_tokens_provider: None,
+        moniker_provider: None,
+        linked_editing_range_provider: None,
+        inline_value_provider: None,
+        inlay_hint_provider: None,
+        diagnostic_provider: Some(DiagnosticServerCapabilities::Options(DiagnosticOptions {
+            identifier: Some("pxp_language_server".to_string()),
+            inter_file_dependencies: true,
+            workspace_diagnostics: true,
+            work_done_progress_options: WorkDoneProgressOptions {
+                work_done_progress: None,
+            },
+        })),
+        experimental: None,
+    }
+}

--- a/crates/pxp-ls/src/lsp.rs
+++ b/crates/pxp-ls/src/lsp.rs
@@ -1,0 +1,191 @@
+use std::sync::Mutex;
+
+use crate::capabilities::get_server_capabilities;
+use pxp_diagnostics::{Diagnostic, Severity};
+use pxp_parser::ParseResult;
+use pxp_parser::ParserDiagnostic;
+use pxp_symbol::SymbolTable;
+use tower_lsp::async_trait;
+use tower_lsp::jsonrpc::Error;
+use tower_lsp::lsp_types;
+use tower_lsp::lsp_types::DiagnosticSeverity;
+use tower_lsp::lsp_types::*;
+use tower_lsp::Client;
+use tower_lsp::LanguageServer;
+
+struct State {
+    diagnostics: dashmap::DashMap<Url, Vec<Diagnostic<ParserDiagnostic>>>
+}
+
+pub(crate) struct Backend {
+    pub(crate) client: Client,
+    state: Mutex<State>
+}
+
+impl Backend {
+
+    pub(crate) fn new(client: Client) -> Backend {
+        Backend {
+            client,
+            state: Mutex::new(State {
+                diagnostics: dashmap::DashMap::new()
+            })
+        }
+    }
+
+    async fn send_diagnostics(&self, uri: Url, content: String) {
+        let diagnostics = self.calculate_diagnostics(&uri, &content).await;
+        self.publish_diagnostics_to_client(uri, &content, &diagnostics).await;
+    }
+
+    async fn calculate_diagnostics(&self, uri: &Url, content: &String) -> Vec<Diagnostic<ParserDiagnostic>>
+    {
+        let mut table = SymbolTable::new();
+        let parse_result: ParseResult = pxp_parser::parse(&content, &mut table);
+
+        match self.state.lock() {
+            Ok(state) => {
+                state.diagnostics.insert(uri.clone(), parse_result.diagnostics.clone());
+            },
+            Err(_) => {}
+        };
+
+        parse_result.diagnostics
+    }
+
+    async fn publish_diagnostics_to_client(
+        &self,
+        uri: Url,
+        text: &String,
+        parser_diagnostics: &Vec<Diagnostic<ParserDiagnostic>>,
+    ) {
+        let mut diagnostics = Vec::new();
+
+        parser_diagnostics.into_iter().for_each(|d| {
+            let severity = match d.severity {
+                Severity::Hint        => DiagnosticSeverity::HINT,
+                Severity::Information => DiagnosticSeverity::INFORMATION,
+                Severity::Warning     => DiagnosticSeverity::WARNING,
+                Severity::Error       => DiagnosticSeverity::ERROR,
+            };
+            
+            let range = self.calculate_line_and_character(&text, d.span.start as u32, d.span.end as u32);
+
+            let message = d.to_string();
+
+            diagnostics.push(lsp_types::Diagnostic {
+                range,
+                severity: Some(severity),
+                code: None,
+                code_description: None,
+                source: None,
+                message,
+                related_information: None,
+                tags: None,
+                data: None,
+            });
+        });
+        self.client
+            .publish_diagnostics(uri, diagnostics, None)
+            .await;
+    }
+
+    fn calculate_line_and_character(&self, text: &str, start: u32, end: u32) -> Range {
+        let lines = text.split('\n').collect::<Vec<&str>>();
+        let mut start_line: u32 = 0;
+        let mut start_char: u32 = 0;
+        let mut end_line: u32 = 0;
+        let mut end_char: u32 = 0;
+
+        let mut offset: u32 = 0;
+
+        for (i, line) in lines.iter().enumerate() {
+            let line_len = line.len() as u32;
+            if offset + line_len >= start {
+                start_line = i as u32;
+                start_char = start - offset;
+            }
+
+            if offset + line_len >= end {
+                end_line = i as u32;
+                end_char = end - offset;
+                break;
+            }
+
+            offset += line_len + 1;
+        }
+
+        Range {
+            start: Position {
+                line: start_line,
+                character: start_char,
+            },
+            end: Position {
+                line: end_line,
+                character: end_char
+            }
+        }
+
+    }
+}
+
+#[async_trait]
+impl LanguageServer for Backend {
+    // Lifecycle Messages
+    async fn initialize(&self, _params: InitializeParams) -> Result<InitializeResult, Error> {
+        return Ok(InitializeResult {
+            capabilities: get_server_capabilities(_params),
+            server_info: None,
+            offset_encoding: None,
+        });
+    }
+
+    async fn initialized(&self, _params: InitializedParams) {
+        self.client
+            .log_message(
+                MessageType::INFO,
+                "PXP Language Server Initialized".to_string(),
+            )
+            .await;
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let content = params.text_document.text;
+        self.send_diagnostics(uri, content).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let content = params.content_changes[0].text.clone();
+        self.send_diagnostics(uri, content).await;
+    }
+
+    async fn did_close(&self, _params: DidCloseTextDocumentParams) {
+        let uri = _params.text_document.uri;
+        self.client
+            .log_message(MessageType::INFO, format!("Closed document: {}", uri))
+            .await;
+
+        match self.state.lock() {
+            Ok(state) => {
+                state.diagnostics.remove(&uri);
+            },
+            Err(_) => {}
+        }
+    }
+
+    async fn did_save(&self, _params: DidSaveTextDocumentParams) {
+        let uri = _params.text_document.uri;
+        let content = _params.text;
+
+        match content {
+            Some(c) => self.send_diagnostics(uri, c).await,
+            None => {}
+        };
+    }
+
+    async fn shutdown(&self) -> Result<(), Error> {
+        Ok(())
+    }
+}

--- a/crates/pxp-ls/src/main.rs
+++ b/crates/pxp-ls/src/main.rs
@@ -1,0 +1,16 @@
+mod lsp;
+mod capabilities;
+
+use tower_lsp::{LspService, Server};
+use lsp::Backend;
+
+#[tokio::main]
+async fn main() {
+
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+    let (service, socket) = LspService::build(|client| Backend::new(client))
+    .finish();
+
+    Server::new(stdin, stdout, socket).serve(service).await;
+}


### PR DESCRIPTION
Hello @ryangjchandler,

First of all, thank you for this initiative. This project is a task that was long overdue and someone had to step up. I hope many more people come and see the potential value of this project for the entire php ecosystem. 

Anyway, I tried to implement the language server protocol with pxp-parser and show the diagnostic information in the lsp client (neovim for me). This can be a starting for many more features as the language/platform as a whole grows. For now, it supports any diagnostics that the parser may generate.

https://github.com/pxp-lang/pxp/assets/18713900/f6c14a70-285d-4531-bdfa-e21c1f2e450a

If you want to try it out in neovim, here's how I configured it using nvim-lspconfig. It should theoretically support any editor with an lsp client, but I haven't tested in other editors.




```lua
    local capabilities = require('cmp_nvim_lsp').default_capabilities();
    local lspconfig = require('lspconfig');
    local config = require('lspconfig.configs');

    config.pxp = {
        default_config = {
            cmd = { '<path-to-pxp-ls-executable>' },
            filetypes = { 'php' },
            root_dir = lspconfig.util.root_pattern('composer.json', '.git'),
            settings = {},
        },
    }

    lspconfig.pxp.setup {
        capabilities = capabilities,
    }

```